### PR TITLE
Feature/fix consumers tests

### DIFF
--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -163,17 +163,24 @@ STATICFILES_DIRS = [
 
 # Channels
 ASGI_APPLICATION = 'manager.routing.application'
-REDIS_HOST = os.environ.get('REDIS_HOST', '127.0.0.1')
-REDIS_PASS = os.environ.get('REDIS_PASS', 'admin123')
-CHANNEL_LAYERS = {
-    'default': {
-        'BACKEND': 'channels_redis.core.RedisChannelLayer',
-        'CONFIG': {
-            "hosts": ["redis://:"+REDIS_PASS+"@"+REDIS_HOST+":6379/0"],
-            "symmetric_encryption_keys": [SECRET_KEY],
+REDIS_HOST = os.environ.get('REDIS_HOST', False)
+REDIS_PASS = os.environ.get('REDIS_PASS', False)
+if REDIS_HOST:
+    CHANNEL_LAYERS = {
+        'default': {
+            'BACKEND': 'channels_redis.core.RedisChannelLayer',
+            'CONFIG': {
+                "hosts": ["redis://:" + REDIS_PASS + "@" + REDIS_HOST + ":6379/0"],
+                "symmetric_encryption_keys": [SECRET_KEY],
+            },
         },
-    },
-}
+    }
+else:
+    CHANNEL_LAYERS = {
+        'default': {
+            'BACKEND': 'channels.layers.InMemoryChannelLayer',
+        },
+    }
 
 # LDAP
 # Baseline configuration:

--- a/manager/subscription/tests/test_connection.py
+++ b/manager/subscription/tests/test_connection.py
@@ -1,0 +1,68 @@
+import pytest
+from django.contrib.auth.models import User
+from channels.testing import WebsocketCommunicator
+from manager.routing import application
+from manager.settings import PROCESS_CONNECTION_PASS
+from api.models import Token
+
+
+class TestClientConnection:
+    """ Test that clients can or cannot connect depending on different conditions """
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db
+    async def test_connection_with_token(self):
+        """ Test that clients can connect with a valid token """
+        # Arrange
+        user = User.objects.create_user('username', password='123', email='user@user.cl')
+        token = Token.objects.create(user=user)
+        url = 'manager/ws/subscription/?token={}'.format(token)
+        communicator = WebsocketCommunicator(application,  url)
+        # Act
+        connected, subprotocol = await communicator.connect()
+        # Assert
+        assert connected, 'Communicator was not connected'
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db
+    async def test_connection_with_password(self):
+        """ Test that clients can connect with a valid password """
+        # Arrange
+        password = PROCESS_CONNECTION_PASS
+        url = 'manager/ws/subscription/?password={}'.format(password)
+        communicator = WebsocketCommunicator(application,  url)
+        # Act
+        connected, subprotocol = await communicator.connect()
+        # Assert
+        assert connected, 'Communicator was not connected'
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db
+    async def test_connection_failed_for_invalid_token(self):
+        """ Test that clients cannot connect with an invalid token """
+        # Arrange
+        user = User.objects.create_user('username', password='123', email='user@user.cl')
+        token = Token.objects.create(user=user)
+        url = 'manager/ws/subscription/?token={}'.format(str(token) + 'fake')
+        communicator = WebsocketCommunicator(application,  url)
+        # Act
+        connected, subprotocol = await communicator.connect()
+        # Assert
+        assert not connected, 'Communicator should not have connected'
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db
+    async def test_connection_failed_for_invalid_password(self):
+        """ Test that clients cannot connect with an invalid password """
+        # Arrange
+        password = PROCESS_CONNECTION_PASS + '_fake'
+        url = 'manager/ws/subscription/?password={}'.format(password)
+        communicator = WebsocketCommunicator(application,  url)
+        # Act
+        connected, subprotocol = await communicator.connect()
+        # Assert
+        assert not connected, 'Communicator should not have connected'
+        await communicator.disconnect()

--- a/manager/tests/test_client_consumer.py
+++ b/manager/tests/test_client_consumer.py
@@ -40,47 +40,6 @@ class TestClientConsumer:
 
     @pytest.mark.asyncio
     @pytest.mark.django_db
-    async def test_connection_with_token(self):
-        # Arrange
-        user = User.objects.create_user('username', password='123', email='user@user.cl')
-        token = Token.objects.create(user=user)
-        url = 'manager/ws/subscription/?token={}'.format(token)
-        communicator = WebsocketCommunicator(application,  url)
-        # Act
-        connected, subprotocol = await communicator.connect()
-        # Assert
-        assert connected, 'Communicator was not connected'
-        await communicator.disconnect()
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db
-    async def test_connection_with_password(self):
-        # Arrange
-        password = PROCESS_CONNECTION_PASS
-        url = 'manager/ws/subscription/?password={}'.format(password)
-        communicator = WebsocketCommunicator(application,  url)
-        # Act
-        connected, subprotocol = await communicator.connect()
-        # Assert
-        assert connected, 'Communicator was not connected'
-        await communicator.disconnect()
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db
-    async def test_connection_failed_for_invalid_token(self):
-        # Arrange
-        user = User.objects.create_user('username', password='123', email='user@user.cl')
-        token = Token.objects.create(user=user)
-        url = 'manager/ws/subscription/?token={}'.format(str(token) + 'fake')
-        communicator = WebsocketCommunicator(application,  url)
-        # Act
-        connected, subprotocol = await communicator.connect()
-        # Assert
-        assert not connected, 'Communicator should not have connected'
-        await communicator.disconnect()
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db
     async def test_join_telemetry_stream(self):
         # Arrange
         user = User.objects.create_user('username', password='123', email='user@user.cl')


### PR DESCRIPTION
Change CHANNELS_LAYER attribute in settings.py in order to use InMemoryChannelLayer when redis is not going to be used. Closes #7 