### PR TITLE
Base64ImageField - naive view_id extraction in file_name 

### DIFF
--- a/manager/ui_framework/serializers.py
+++ b/manager/ui_framework/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from ui_framework.models import Workspace, View, WorkspaceView
 from django.conf import settings
 
+
 class Base64ImageField(serializers.ImageField):
     """
     A Django REST framework field for handling image-uploads through raw post data.
@@ -37,7 +38,12 @@ class Base64ImageField(serializers.ImageField):
                 decoded_file = base64.b64decode(data)
             except TypeError:
                 self.fail('invalid_image')
-            view_id = self.parent.context['request'].data['id']
+
+            
+            view_id = View.objects.count() + 1 
+            # id field should come in req data if iew exists
+            if 'id'  in self.parent.context['request'].data: 
+                view_id = self.parent.context['request'].data['id']
             # Generate file name:
             file_name = f'view_{view_id}'
             # Get the file name extension:
@@ -56,13 +62,13 @@ class Base64ImageField(serializers.ImageField):
         extension = "jpg" if extension == "jpeg" else extension
 
         return extension
-        
+
+
 class ViewSerializer(serializers.ModelSerializer):
     """Serializer for the View model."""
     thumbnail = Base64ImageField(
-        required=False, max_length=None, use_url=False, allow_empty_file=True, allow_null=True,
-    )
-
+            required=False, max_length=None, use_url=False, allow_empty_file=True, allow_null=True)
+    
     class Meta:
         """Meta class to map serializer's fields with the model fields."""
 

--- a/manager/ui_framework/serializers.py
+++ b/manager/ui_framework/serializers.py
@@ -2,6 +2,7 @@
 from rest_framework import serializers
 from ui_framework.models import Workspace, View, WorkspaceView
 from django.conf import settings
+from django.db.models import Max
 
 
 class Base64ImageField(serializers.ImageField):
@@ -14,6 +15,21 @@ class Base64ImageField(serializers.ImageField):
 
     Updated for Django REST framework 3.
     """
+    @staticmethod
+    def _get_view_id_from_data(data):
+        """ Returns a view_id integer for building the thumbnail file_namet
+        by checking whether the id comes in the request data or if a new one 
+        has to be created """
+        # id field should come in req data if view exists
+        if 'id' in data:
+            return data['id']
+
+        # safe to assume that max(id)+1 can be overwritten
+        view_id_max = View.objects.aggregate(Max('id'))
+        if view_id_max['id_max'] is None:
+            return 1
+
+        return view_id_max['id__max'] + 1
 
     def to_representation(self, value):
         return settings.MEDIA_URL + str(value)
@@ -39,13 +55,11 @@ class Base64ImageField(serializers.ImageField):
             except TypeError:
                 self.fail('invalid_image')
 
-            
-            view_id = View.objects.count() + 1 
-            # id field should come in req data if iew exists
-            if 'id'  in self.parent.context['request'].data: 
-                view_id = self.parent.context['request'].data['id']
+
             # Generate file name:
+            view_id = self._get_view_id_from_data(self.parent.context['request'].data)
             file_name = f'view_{view_id}'
+            
             # Get the file name extension:
             file_extension = self.get_file_extension(file_name, decoded_file)
 
@@ -67,8 +81,8 @@ class Base64ImageField(serializers.ImageField):
 class ViewSerializer(serializers.ModelSerializer):
     """Serializer for the View model."""
     thumbnail = Base64ImageField(
-            required=False, max_length=None, use_url=False, allow_empty_file=True, allow_null=True)
-    
+        required=False, max_length=None, use_url=False, allow_empty_file=True, allow_null=True)
+
     class Meta:
         """Meta class to map serializer's fields with the model fields."""
 


### PR DESCRIPTION
https://github.com/lsst-ts/LOVE-manager/blob/211dbc8a46a4517196487fc3d44874cf3a2a9bbd/manager/ui_framework/serializers.py#L40

This line assumes the request comes with the `id` key which is true when editing existing views but not for new ones. This is corrected now by assigning the `max(id)+1` value or `1` if no views exist in the database.