### PR TITLE
Feature/time api

### DIFF
--- a/manager/api/serializers.py
+++ b/manager/api/serializers.py
@@ -2,7 +2,7 @@
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from django.contrib.auth.models import User
-from astropy.time import Time
+from manager.utils import tai_utc_offset
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -14,14 +14,14 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         """The model class to serialize"""
 
-        fields = ('username', 'email')
+        fields = ("username", "email")
         """The fields of the model class to serialize"""
 
 
 class UserPermissionsSerializer(serializers.Serializer):
     """Custom Serializer for user permissions."""
 
-    execute_commands = serializers.SerializerMethodField('can_execute_commands')
+    execute_commands = serializers.SerializerMethodField("can_execute_commands")
 
     def can_execute_commands(self, user) -> bool:
         """Define wether or not the given user has permissions to execute commands.
@@ -36,7 +36,7 @@ class UserPermissionsSerializer(serializers.Serializer):
         Bool
             True if the user can execute commands, False if not.
         """
-        return user.has_perm('api.command.execute_command')
+        return user.has_perm("api.command.execute_command")
 
 
 class TokenSerializer(serializers.Serializer):
@@ -44,11 +44,11 @@ class TokenSerializer(serializers.Serializer):
 
     user = UserSerializer()
 
-    token = serializers.SerializerMethodField('get_token')
+    token = serializers.SerializerMethodField("get_token")
 
-    permissions = serializers.SerializerMethodField('get_permissions')
+    permissions = serializers.SerializerMethodField("get_permissions")
 
-    tai_to_utc = serializers.SerializerMethodField('get_tai_to_utc')
+    tai_to_utc = serializers.SerializerMethodField("get_tai_to_utc")
 
     @swagger_serializer_method(serializer_or_field=UserPermissionsSerializer)
     def get_permissions(self, token):
@@ -94,6 +94,4 @@ class TokenSerializer(serializers.Serializer):
         Int
             The number of seconds of difference between TAI and UTC times
         """
-        t = Time.now()
-        dt = (t.datetime.timestamp() - t.tai.datetime.timestamp())
-        return dt
+        return tai_utc_offset()

--- a/manager/api/serializers.py
+++ b/manager/api/serializers.py
@@ -64,8 +64,6 @@ class TokenSerializer(serializers.Serializer):
 
     permissions = serializers.SerializerMethodField("get_permissions")
 
-    tai_to_utc = serializers.SerializerMethodField("get_tai_to_utc")
-
     time_data = serializers.SerializerMethodField("get_time_data")
 
     @swagger_serializer_method(serializer_or_field=UserPermissionsSerializer)
@@ -98,21 +96,6 @@ class TokenSerializer(serializers.Serializer):
             The token key
         """
         return token.key
-
-    def get_tai_to_utc(self, token) -> float:
-        """Return the difference in seconds between TAI and UTC Timestamps.
-
-        Params
-        ------
-        token: Token
-            The Token object
-
-        Returns
-        -------
-        Int
-            The number of seconds of difference between TAI and UTC times
-        """
-        return utils.get_tai_to_utc()
 
     @swagger_serializer_method(serializer_or_field=TimeDataSerializer)
     def get_time_data(self, token) -> dict:

--- a/manager/api/tests/tests_auth_api.py
+++ b/manager/api/tests/tests_auth_api.py
@@ -8,7 +8,7 @@ from rest_framework.test import APIClient
 from rest_framework import status
 from api.models import Token
 from django.conf import settings
-from astropy.time import Time
+from manager import utils
 
 
 class AuthApiTestCase(TestCase):
@@ -34,23 +34,6 @@ class AuthApiTestCase(TestCase):
         self.expected_permissions = {
             "execute_commands": True,
         }
-
-    def assert_time_data(self, time_data):
-        """Asserts the structure of the time_data dictionary."""
-
-        if not isinstance(time_data["utc"], float):
-            return False
-        if not isinstance(time_data["tai"], float):
-            return False
-        if not isinstance(time_data["mjd"], float):
-            return False
-        if not isinstance(time_data["sidereal_summit"], float):
-            return False
-        if not isinstance(time_data["sidereal_greenwich"], float):
-            return False
-        if not isinstance(time_data["tai_to_utc"], float):
-            return False
-        return True
 
     def test_user_login(self):
         """Test that a user can request a token using name and password."""
@@ -84,15 +67,13 @@ class AuthApiTestCase(TestCase):
             {"username": self.user.username, "email": self.user.email},
             "The user is not as expected",
         )
-        t = Time.now()
-        dt = t.datetime.timestamp() - t.tai.datetime.timestamp()
         self.assertEqual(
             response.data["tai_to_utc"],
-            dt,
+            utils.get_tai_to_utc(),
             "The taiToUTC transformation is not as expected",
         )
         self.assertTrue(
-            self.assert_time_data(response.data["time_data"]),
+            utils.assert_time_data(response.data["time_data"]),
             "Time data is not as expected",
         )
 
@@ -179,15 +160,13 @@ class AuthApiTestCase(TestCase):
             {"username": self.user.username, "email": self.user.email,},
             "The user is not as expected",
         )
-        t = Time.now()
-        dt = t.datetime.timestamp() - t.tai.datetime.timestamp()
         self.assertEqual(
             response.data["tai_to_utc"],
-            dt,
+            utils.get_tai_to_utc(),
             "The taiToUTC transformation is not as expected",
         )
         self.assertTrue(
-            self.assert_time_data(response.data["time_data"]),
+            utils.assert_time_data(response.data["time_data"]),
             "Time data is not as expected",
         )
 

--- a/manager/api/tests/tests_auth_api.py
+++ b/manager/api/tests/tests_auth_api.py
@@ -18,156 +18,189 @@ class AuthApiTestCase(TestCase):
         """Define the test suite setup."""
         # Arrange:
         self.client = APIClient()
-        self.username = 'test'
-        self.password = 'password'
+        self.username = "test"
+        self.password = "password"
         self.user = User.objects.create_user(
             username=self.username,
-            password='password',
-            email='test@user.cl',
-            first_name='First',
-            last_name='Last',
+            password="password",
+            email="test@user.cl",
+            first_name="First",
+            last_name="Last",
         )
-        self.user.user_permissions.add(Permission.objects.get(name='Execute Commands'))
-        self.login_url = reverse('login')
-        self.validate_token_url = reverse('validate-token')
-        self.logout_url = reverse('logout')
+        self.user.user_permissions.add(Permission.objects.get(name="Execute Commands"))
+        self.login_url = reverse("login")
+        self.validate_token_url = reverse("validate-token")
+        self.logout_url = reverse("logout")
         self.expected_permissions = {
-            'execute_commands': True,
+            "execute_commands": True,
         }
+
+    def assert_time_data(self, time_data):
+        """Asserts the structure of the time_data dictionary."""
+
+        if not isinstance(time_data["utc"], float):
+            return False
+        if not isinstance(time_data["tai"], float):
+            return False
+        if not isinstance(time_data["mjd"], float):
+            return False
+        if not isinstance(time_data["sidereal_summit"], float):
+            return False
+        if not isinstance(time_data["sidereal_greenwich"], float):
+            return False
+        if not isinstance(time_data["tai_to_utc"], float):
+            return False
+        return True
 
     def test_user_login(self):
         """Test that a user can request a token using name and password."""
         # Arrange:
-        data = {'username': self.username, 'password': self.password}
+        data = {"username": self.username, "password": self.password}
         tokens_num_0 = Token.objects.filter(user__username=self.username).count()
 
         # Act:
-        response = self.client.post(self.login_url, data, format='json')
+        response = self.client.post(self.login_url, data, format="json")
 
         # Assert:
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         tokens_num = Token.objects.filter(user__username=self.username).count()
-        self.assertEqual(tokens_num_0 + 1, tokens_num, 'The user should have a new token')
-        tokens_in_db = [t.key for t in Token.objects.filter(user__username=self.username)]
-        retrieved_token = response.data['token']
-        self.assertTrue(retrieved_token in tokens_in_db, 'The token should be in the DB')
         self.assertEqual(
-            response.data['permissions'],
-            self.expected_permissions,
-            'The permissions are not as expected'
+            tokens_num_0 + 1, tokens_num, "The user should have a new token"
+        )
+        tokens_in_db = [
+            t.key for t in Token.objects.filter(user__username=self.username)
+        ]
+        retrieved_token = response.data["token"]
+        self.assertTrue(
+            retrieved_token in tokens_in_db, "The token should be in the DB"
         )
         self.assertEqual(
-            response.data['user'],
-            {
-                'username': self.user.username,
-                'email': self.user.email,
-            },
-            'The user is not as expected'
+            response.data["permissions"],
+            self.expected_permissions,
+            "The permissions are not as expected",
+        )
+        self.assertEqual(
+            response.data["user"],
+            {"username": self.user.username, "email": self.user.email},
+            "The user is not as expected",
         )
         t = Time.now()
-        dt = (t.datetime.timestamp() - t.tai.datetime.timestamp())
+        dt = t.datetime.timestamp() - t.tai.datetime.timestamp()
         self.assertEqual(
-            response.data['tai_to_utc'],
+            response.data["tai_to_utc"],
             dt,
-            'The taiToUTC transformation is not as expected'
+            "The taiToUTC transformation is not as expected",
+        )
+        self.assertTrue(
+            self.assert_time_data(response.data["time_data"]),
+            "Time data is not as expected",
         )
 
     def test_user_login_failed(self):
         """Test that a user cannot request a token if the credentials are invalid."""
         # Arrange:
-        data = {'username': self.username, 'password': 'wrong-password'}
+        data = {"username": self.username, "password": "wrong-password"}
         tokens_num_0 = Token.objects.filter(user__username=self.username).count()
 
         # Act:
-        response = self.client.post(self.login_url, data, format='json')
+        response = self.client.post(self.login_url, data, format="json")
 
         # Assert:
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         tokens_num_1 = Token.objects.filter(user__username=self.username).count()
-        self.assertEqual(tokens_num_0, tokens_num_1, 'The user should have no token')
+        self.assertEqual(tokens_num_0, tokens_num_1, "The user should have no token")
 
     def test_user_login_twice(self):
         """Test that a user can request a token twie receiving different tokens each time."""
         # Arrange:
-        data = {'username': self.username, 'password': self.password}
+        data = {"username": self.username, "password": self.password}
         tokens_num_0 = Token.objects.filter(user__username=self.username).count()
 
         # Act 1:
-        response = self.client.post(self.login_url, data, format='json')
+        response = self.client.post(self.login_url, data, format="json")
 
         # Assert 1:
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         tokens_num_1 = Token.objects.filter(user__username=self.username).count()
-        self.assertEqual(tokens_num_0 + 1, tokens_num_1, 'The user should have a new token')
-        retrieved_token_1 = response.data['token']
-        tokens_in_db = [t.key for t in Token.objects.filter(user__username=self.username)]
-        self.assertTrue(retrieved_token_1 in tokens_in_db, 'The token should be in the DB')
+        self.assertEqual(
+            tokens_num_0 + 1, tokens_num_1, "The user should have a new token"
+        )
+        retrieved_token_1 = response.data["token"]
+        tokens_in_db = [
+            t.key for t in Token.objects.filter(user__username=self.username)
+        ]
+        self.assertTrue(
+            retrieved_token_1 in tokens_in_db, "The token should be in the DB"
+        )
 
         # Act 2:
-        response = self.client.post(self.login_url, data, format='json')
+        response = self.client.post(self.login_url, data, format="json")
 
         # Assert after request 2:
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         tokens_num_2 = Token.objects.filter(user__username=self.username).count()
-        self.assertEqual(tokens_num_1 + 1, tokens_num_2, 'The user should have another new token')
-        retrieved_token_2 = response.data['token']
-        tokens_in_db = [t.key for t in Token.objects.filter(user__username=self.username)]
-        self.assertTrue(retrieved_token_1 in tokens_in_db, 'The token should be in the DB')
-        self.assertNotEqual(retrieved_token_1, retrieved_token_2, 'The tokens should be different')
+        self.assertEqual(
+            tokens_num_1 + 1, tokens_num_2, "The user should have another new token"
+        )
+        retrieved_token_2 = response.data["token"]
+        tokens_in_db = [
+            t.key for t in Token.objects.filter(user__username=self.username)
+        ]
+        self.assertTrue(
+            retrieved_token_1 in tokens_in_db, "The token should be in the DB"
+        )
+        self.assertNotEqual(
+            retrieved_token_1, retrieved_token_2, "The tokens should be different"
+        )
 
     def test_user_validate_token(self):
         """Test that a user can validate a token."""
         # Arrange:
-        data = {'username': self.username, 'password': self.password}
-        response = self.client.post(self.login_url, data, format='json')
+        data = {"username": self.username, "password": self.password}
+        response = self.client.post(self.login_url, data, format="json")
         token = Token.objects.filter(user__username=self.username).first()
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
 
         # Act:
-        response = self.client.get(
-            self.validate_token_url, data, format='json'
-        )
+        response = self.client.get(self.validate_token_url, data, format="json")
 
         # Assert after request:
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.data['token'],
-            token.key,
-            'The response is not as expected'
+            response.data["token"], token.key, "The response is not as expected"
         )
         self.assertEqual(
-            response.data['permissions'],
+            response.data["permissions"],
             self.expected_permissions,
-            'The permissions are not as expected'
+            "The permissions are not as expected",
         )
         self.assertEqual(
-            response.data['user'],
-            {
-                'username': self.user.username,
-                'email': self.user.email,
-            },
-            'The user is not as expected'
+            response.data["user"],
+            {"username": self.user.username, "email": self.user.email,},
+            "The user is not as expected",
         )
         t = Time.now()
-        dt = (t.datetime.timestamp() - t.tai.datetime.timestamp())
+        dt = t.datetime.timestamp() - t.tai.datetime.timestamp()
         self.assertEqual(
-            response.data['tai_to_utc'],
+            response.data["tai_to_utc"],
             dt,
-            'The taiToUTC transformation is not as expected'
+            "The taiToUTC transformation is not as expected",
+        )
+        self.assertTrue(
+            self.assert_time_data(response.data["time_data"]),
+            "Time data is not as expected",
         )
 
     def test_user_validate_token_fail(self):
         """Test that a user fails to validate an invalid token."""
         # Arrange:
-        data = {'username': self.username, 'password': self.password}
-        response = self.client.post(self.login_url, data, format='json')
+        data = {"username": self.username, "password": self.password}
+        response = self.client.post(self.login_url, data, format="json")
         token = Token.objects.filter(user__username=self.username).first()
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key + 'fake')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key + "fake")
 
         # Act:
-        response = self.client.get(
-            self.validate_token_url, data, format='json'
-        )
+        response = self.client.get(self.validate_token_url, data, format="json")
 
         # Assert after request:
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -175,16 +208,14 @@ class AuthApiTestCase(TestCase):
     def test_user_fails_to_validate_deleted_token(self):
         """Test that a user fails to validate an deleted token."""
         # Arrange:
-        data = {'username': self.username, 'password': self.password}
-        response = self.client.post(self.login_url, data, format='json')
+        data = {"username": self.username, "password": self.password}
+        response = self.client.post(self.login_url, data, format="json")
         token = Token.objects.filter(user__username=self.username).first()
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
         token.delete()
 
         # Act:
-        response = self.client.get(
-            self.validate_token_url, format='json'
-        )
+        response = self.client.get(self.validate_token_url, format="json")
 
         # Assert:
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -194,18 +225,18 @@ class AuthApiTestCase(TestCase):
         # Arrange:
         initial_time = datetime.datetime.now()
         with freeze_time(initial_time) as frozen_datetime:
-            data = {'username': self.username, 'password': self.password}
-            response = self.client.post(self.login_url, data, format='json')
+            data = {"username": self.username, "password": self.password}
+            response = self.client.post(self.login_url, data, format="json")
             token = Token.objects.filter(user__username=self.username).first()
             token_num_0 = Token.objects.filter(user__username=self.username).count()
-            self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+            self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
 
             # Act:
-            max_timedelta = datetime.timedelta(days=settings.TOKEN_EXPIRED_AFTER_DAYS, seconds=1)
-            frozen_datetime.tick(delta=max_timedelta)
-            response = self.client.get(
-                self.validate_token_url, format='json'
+            max_timedelta = datetime.timedelta(
+                days=settings.TOKEN_EXPIRED_AFTER_DAYS, seconds=1
             )
+            frozen_datetime.tick(delta=max_timedelta)
+            response = self.client.get(self.validate_token_url, format="json")
 
             # Assert:
             token_num_1 = Token.objects.filter(user__username=self.username).count()
@@ -215,21 +246,24 @@ class AuthApiTestCase(TestCase):
     def test_user_logout(self):
         """Test that a user can logout and delete the token."""
         # Arrange:
-        data = {'username': self.username, 'password': self.password}
-        response = self.client.post(self.login_url, data, format='json')
+        data = {"username": self.username, "password": self.password}
+        response = self.client.post(self.login_url, data, format="json")
         token = Token.objects.filter(user__username=self.username).first()
         old_tokens_count = Token.objects.filter(user__username=self.username).count()
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
 
         # Act:
-        response = self.client.delete(self.logout_url, format='json')
+        response = self.client.delete(self.logout_url, format="json")
 
         # Assert:
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(
             response.data,
-            {'detail': 'Logout successful, Token succesfully deleted'},
-            'The response is not as expected'
+            {"detail": "Logout successful, Token succesfully deleted"},
+            "The response is not as expected",
         )
         new_tokens_count = Token.objects.filter(user__username=self.username).count()
-        self.assertEqual(old_tokens_count - 1, new_tokens_count, 'The token was not deleted')
+        self.assertEqual(
+            old_tokens_count - 1, new_tokens_count, "The token was not deleted"
+        )
+

--- a/manager/api/tests/tests_auth_api.py
+++ b/manager/api/tests/tests_auth_api.py
@@ -67,11 +67,6 @@ class AuthApiTestCase(TestCase):
             {"username": self.user.username, "email": self.user.email},
             "The user is not as expected",
         )
-        self.assertEqual(
-            response.data["tai_to_utc"],
-            utils.get_tai_to_utc(),
-            "The taiToUTC transformation is not as expected",
-        )
         self.assertTrue(
             utils.assert_time_data(response.data["time_data"]),
             "Time data is not as expected",
@@ -159,11 +154,6 @@ class AuthApiTestCase(TestCase):
             response.data["user"],
             {"username": self.user.username, "email": self.user.email,},
             "The user is not as expected",
-        )
-        self.assertEqual(
-            response.data["tai_to_utc"],
-            utils.get_tai_to_utc(),
-            "The taiToUTC transformation is not as expected",
         )
         self.assertTrue(
             utils.assert_time_data(response.data["time_data"]),

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -41,3 +41,20 @@ def get_times():
         "sidereal_greenwich": sidereal_greenwich.value,
         "tai_to_utc": t_utc - t_tai,
     }
+
+def assert_time_data(time_data):
+        """Asserts the structure of the time_data dictionary."""
+
+        if not isinstance(time_data["utc"], float):
+            return False
+        if not isinstance(time_data["tai"], float):
+            return False
+        if not isinstance(time_data["mjd"], float):
+            return False
+        if not isinstance(time_data["sidereal_summit"], float):
+            return False
+        if not isinstance(time_data["sidereal_greenwich"], float):
+            return False
+        if not isinstance(time_data["tai_to_utc"], float):
+            return False
+        return True

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -12,3 +12,19 @@ def tai_utc_offset() -> float:
     t = Time.now()
     dt = t.datetime.timestamp() - t.tai.datetime.timestamp()
     return dt
+
+
+def get_times():
+    t = Time.now()
+    t_utc = t.datetime.timestamp()
+    t_tai = t.tai.datetime.timestamp()
+    sidereal_summit = t.sidereal_time("apparent", longitude=-70.749417, model=None)
+    sidereal_greenwich = t.sidereal_time("apparent", longitude="greenwich", model=None)
+    return {
+        "utc": t_utc,
+        "tai": t_tai,
+        "mjd": t.mjd,
+        "sidereal_summit": sidereal_summit.value,
+        "sidereal_greenwich": sidereal_greenwich.value,
+        "tai_to_utc": t_utc - t_tai,
+    }

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -1,7 +1,7 @@
 from astropy.time import Time
 
 
-def tai_utc_offset() -> float:
+def get_tai_to_utc() -> float:
     """Return the difference in seconds between TAI and UTC Timestamps.
 
     Returns
@@ -15,6 +15,19 @@ def tai_utc_offset() -> float:
 
 
 def get_times():
+    """Return relevant time measures.
+
+        Returns
+        -------
+        Dict
+            Dictionary containing the following keys:
+            - utc: current time in UTC scale as a unix timestamp (seconds)
+            - tai: current time in UTC scale as a unix timestamp (seconds)
+            - mjd: current time as a modified julian date
+            - sidereal_summit: current time as a sidereal_time w/respect to the summit location (hourangles)
+            - sidereal_summit: current time as a sidereal_time w/respect to Greenwich location (hourangles)
+            - tai_to_utc: The number of seconds of difference between TAI and UTC times (seconds)
+    """
     t = Time.now()
     t_utc = t.datetime.timestamp()
     t_tai = t.tai.datetime.timestamp()

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -1,0 +1,14 @@
+from astropy.time import Time
+
+
+def tai_utc_offset() -> float:
+    """Return the difference in seconds between TAI and UTC Timestamps.
+
+    Returns
+    -------
+    Int
+        The number of seconds of difference between TAI and UTC times
+    """
+    t = Time.now()
+    dt = t.datetime.timestamp() - t.tai.datetime.timestamp()
+    return dt

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -6,6 +6,7 @@ import datetime
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from manager.settings import PROCESS_CONNECTION_PASS
+from manager import utils
 from subscription.heartbeat_manager import HeartbeatManager
 
 
@@ -55,6 +56,8 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         """
         if "option" in message:
             await self.handle_subscription_message(message)
+        elif "action" in message:
+            await self.handle_action_message(message)
         else:
             await self.handle_data_message(message)
 
@@ -107,6 +110,16 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                 }
             )
             return
+    
+    async def handle_action_message(self, message):
+        time_data = utils.get_times()
+        await self.send_json(
+            {
+                "time_data": json.dumps(time_data)
+            }
+        )
+        return
+
 
     async def handle_data_message(self, message):
         """Handle a data message.

--- a/manager/subscription/tests/test_time_data.py
+++ b/manager/subscription/tests/test_time_data.py
@@ -1,0 +1,39 @@
+"""Tests for the subscription of consumers to love_csc streams."""
+import pytest
+import json
+from django.contrib.auth.models import User, Permission
+from channels.testing import WebsocketCommunicator
+from manager.routing import application
+from api.models import Token
+from manager import utils
+
+
+class TestTimeData:
+    def setup_method(self):
+        """Set up the TestCase, executed before each test of the TestCase."""
+        self.user = User.objects.create_user(
+            "username", password="123", email="user@user.cl"
+        )
+        self.token = Token.objects.create(user=self.user)
+        self.user.user_permissions.add(Permission.objects.get(name="Execute Commands"))
+        self.url = "manager/ws/subscription/?token={}".format(self.token)
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_get_time_data(self):
+        # Arrange
+        communicator = WebsocketCommunicator(application, self.url)
+        connected, subprotocol = await communicator.connect()
+
+        # Act 1 (Subscribe)
+        msg = {
+            "action": "get_time_data",
+        }
+        await communicator.send_json_to(msg)
+        response = await communicator.receive_json_from()
+        time_data = json.loads(response["time_data"])
+        print('time_data:', time_data)
+
+        # Assert 1
+        assert utils.assert_time_data(time_data)
+        await communicator.disconnect()


### PR DESCRIPTION
Change responses of validate token and get token requests, instead of having a `tai_to_utc` field, its has the following:
```
{
  time_data: {
    utc: <utc time in seconds>,
    tai: <tai time in seconds>,
    mjd: <modified julian date in days>,
    sidereal_summit: <Local (summit) Apparent Sidereal Time in hourangles>,
    sidereal_greenwich: <Greenwich Apparent Sidereal Time (GAST)  in hourangles>,
  }
}
```