### PR TITLE
Feature/commander topic names

### DIFF
--- a/manager/api/tests/test_commander.py
+++ b/manager/api/tests/test_commander.py
@@ -145,5 +145,5 @@ class SalinfoTestCase(TestCase):
             response = self.client.get(url)
         fakehostname = "fakehost"
         fakeport = "fakeport"
-        expected_url = f"http://fakehost:fakeport/salinfo/metadata"
+        expected_url = f"http://fakehost:fakeport/salinfo/topic-names"
         self.assertEqual(mock_requests.call_args, call(expected_url))

--- a/manager/api/tests/test_commander.py
+++ b/manager/api/tests/test_commander.py
@@ -16,76 +16,73 @@ class CommanderTestCase(TestCase):
         # Arrange
         self.client = APIClient()
         self.user = User.objects.create_user(
-            username='an user',
-            password='password',
-            email='test@user.cl',
-            first_name='First',
-            last_name='Last',
+            username="an user",
+            password="password",
+            email="test@user.cl",
+            first_name="First",
+            last_name="Last",
         )
         self.token = Token.objects.create(user=self.user)
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
-        self.user.user_permissions.add(Permission.objects.get(codename='view_view'),
-                                       Permission.objects.get(codename='add_view'),
-                                       Permission.objects.get(codename='delete_view'),
-                                       Permission.objects.get(codename='change_view'))
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        self.user.user_permissions.add(
+            Permission.objects.get(codename="view_view"),
+            Permission.objects.get(codename="add_view"),
+            Permission.objects.get(codename="delete_view"),
+            Permission.objects.get(codename="change_view"),
+        )
 
-    @patch('os.environ.get', side_effect= lambda arg: 'fakehost' if arg=='COMMANDER_HOSTNAME' else 'fakeport')
-    @patch('requests.post')
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.post")
     def test_authorized_commander_data(self, mock_requests, mock_environ):
         """Test authorized user commander data is sent to love-commander"""
         # Arrange:
-        self.user.user_permissions.add(Permission.objects.get(name='Execute Commands'))
+        self.user.user_permissions.add(Permission.objects.get(name="Execute Commands"))
 
         # Act:
-        url = reverse('commander')
+        url = reverse("commander")
         data = {
-            'csc': 'Test',
-            'salindex': 1,
-            'cmd': 'cmd_setScalars',
-            'params': {
-                'a': 1,
-                'b': 2
-            }
+            "csc": "Test",
+            "salindex": 1,
+            "cmd": "cmd_setScalars",
+            "params": {"a": 1, "b": 2},
         }
 
         with self.assertRaises(ValueError):
-            response = self.client.post(url, data, format='json')
-        fakehostname = 'fakehost'
-        fakeport = 'fakeport'
+            response = self.client.post(url, data, format="json")
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
         expected_url = f"http://fakehost:fakeport/cmd"
-        self.assertEqual(
-            mock_requests.call_args,
-            call(expected_url, json=data)
-        )
-    
-    @patch('os.environ.get', side_effect= lambda arg: 'fakehost' if arg=='COMMANDER_HOSTNAME' else 'fakeport')
-    @patch('requests.post')
+        self.assertEqual(mock_requests.call_args, call(expected_url, json=data))
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.post")
     def test_unauthorized_commander(self, mock_requests, mock_environ):
         """Test an unauthorized user can't send commands"""
         # Act:
-        url = reverse('commander')
+        url = reverse("commander")
         data = {
-            'csc': 'Test',
-            'salindex': 1,
-            'cmd': 'cmd_setScalars',
-            'params': {
-                'a': 1,
-                'b': 2
-            }
+            "csc": "Test",
+            "salindex": 1,
+            "cmd": "cmd_setScalars",
+            "params": {"a": 1, "b": 2},
         }
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
         result = response.json()
 
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
-            response.status_code,
-            401
-        )
-        self.assertEqual(
-            result,
-            {
-                "ack": "User does not have permissions to execute commands."
-            }
+            result, {"ack": "User does not have permissions to execute commands."}
         )
 
 
@@ -98,32 +95,55 @@ class SalinfoTestCase(TestCase):
         # Arrange
         self.client = APIClient()
         self.user = User.objects.create_user(
-            username='an user',
-            password='password',
-            email='test@user.cl',
-            first_name='First',
-            last_name='Last',
+            username="an user",
+            password="password",
+            email="test@user.cl",
+            first_name="First",
+            last_name="Last",
         )
         self.token = Token.objects.create(user=self.user)
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
-        self.user.user_permissions.add(Permission.objects.get(codename='view_view'),
-                                       Permission.objects.get(codename='add_view'),
-                                       Permission.objects.get(codename='delete_view'),
-                                       Permission.objects.get(codename='change_view'))
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        self.user.user_permissions.add(
+            Permission.objects.get(codename="view_view"),
+            Permission.objects.get(codename="add_view"),
+            Permission.objects.get(codename="delete_view"),
+            Permission.objects.get(codename="change_view"),
+        )
 
-    @patch('os.environ.get', side_effect= lambda arg: 'fakehost' if arg=='COMMANDER_HOSTNAME' else 'fakeport')
-    @patch('requests.get')
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.get")
     def test_salinfo_metadata(self, mock_requests, mock_environ):
         """Test authorized user can get salinfo metadata"""
         # Act:
-        url = reverse('salinfo-metadata')
+        url = reverse("salinfo-metadata")
 
         with self.assertRaises(ValueError):
             response = self.client.get(url)
-        fakehostname = 'fakehost'
-        fakeport = 'fakeport'
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
         expected_url = f"http://fakehost:fakeport/salinfo/metadata"
-        self.assertEqual(
-            mock_requests.call_args,
-            call(expected_url)
-        )
+        self.assertEqual(mock_requests.call_args, call(expected_url))
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.get")
+    def test_salinfo_topic_names(self, mock_requests, mock_environ):
+        """Test authorized user can get salinfo topic_names"""
+        # Act:
+        url = reverse("salinfo-topic-names")
+
+        with self.assertRaises(ValueError):
+            response = self.client.get(url)
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
+        expected_url = f"http://fakehost:fakeport/salinfo/metadata"
+        self.assertEqual(mock_requests.call_args, call(expected_url))

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
     path("auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("cmd/", api.views.commander, name="commander"),
     path("salinfo/metadata", api.views.salinfo_metadata, name="salinfo-metadata"),
-    path("salinfo/topic_names", api.views.salinfo_metadata, name="salinfo-topic-names"),
+    path(
+        "salinfo/topic-names", api.views.salinfo_topic_names, name="salinfo-topic-names"
+    ),
 ]
 urlpatterns.append(path("", include(router.urls)))

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -18,18 +18,24 @@ Including another URLconf
 from django.conf.urls import include
 from django.urls import path
 from rest_framework.routers import DefaultRouter
+
 # from api.views import validate_token, logout, CustomObtainAuthToken, validate_config_schema, commander, salinfo_metadata
 import api.views
 
 router = DefaultRouter()
 
 urlpatterns = [
-    path('get-token/', api.views.CustomObtainAuthToken.as_view(), name='login'),
-    path('validate-token/', api.views.validate_token, name='validate-token'),
-    path('validate-config-schema/', api.views.validate_config_schema, name='validate-config-schema'),
-    path('logout/', api.views.logout, name='logout'),
-    path('auth/', include('rest_framework.urls', namespace='rest_framework')),
-    path('cmd/', api.views.commander, name='commander'),
-    path('salinfo/metadata', api.views.salinfo_metadata, name='salinfo-metadata'),
+    path("get-token/", api.views.CustomObtainAuthToken.as_view(), name="login"),
+    path("validate-token/", api.views.validate_token, name="validate-token"),
+    path(
+        "validate-config-schema/",
+        api.views.validate_config_schema,
+        name="validate-config-schema",
+    ),
+    path("logout/", api.views.logout, name="logout"),
+    path("auth/", include("rest_framework.urls", namespace="rest_framework")),
+    path("cmd/", api.views.commander, name="commander"),
+    path("salinfo/metadata", api.views.salinfo_metadata, name="salinfo-metadata"),
+    path("salinfo/topic_names", api.views.salinfo_metadata, name="salinfo-topic-names"),
 ]
-urlpatterns.append(path('', include(router.urls)))
+urlpatterns.append(path("", include(router.urls)))

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -15,12 +15,15 @@ from rest_framework.response import Response
 from api.models import Token
 from api.serializers import TokenSerializer
 from .schema_validator import DefaultingValidator
-valid_response = openapi.Response('Valid token', TokenSerializer)
-invalid_response = openapi.Response('Invalid token')
+
+valid_response = openapi.Response("Valid token", TokenSerializer)
+invalid_response = openapi.Response("Invalid token")
 
 
-@swagger_auto_schema(method='get', responses={200: valid_response, 401: invalid_response})
-@api_view(['GET'])
+@swagger_auto_schema(
+    method="get", responses={200: valid_response, 401: invalid_response}
+)
+@api_view(["GET"])
 @permission_classes((IsAuthenticated,))
 def validate_token(request):
     """Validate the token and return 200 code if valid.
@@ -32,13 +35,15 @@ def validate_token(request):
     Response
         The response stating that the token is valid with a 200 status code.
     """
-    token_key = request.META.get('HTTP_AUTHORIZATION')[6:]
+    token_key = request.META.get("HTTP_AUTHORIZATION")[6:]
     token = Token.objects.get(key=token_key)
     return Response(TokenSerializer(token).data)
 
 
-@swagger_auto_schema(method='delete', responses={204: openapi.Response('Logout Successful')})
-@api_view(['DELETE'])
+@swagger_auto_schema(
+    method="delete", responses={204: openapi.Response("Logout Successful")}
+)
+@api_view(["DELETE"])
 @permission_classes((IsAuthenticated,))
 def logout(request):
     """Logout and delete the token. And returns 204 code if valid.
@@ -52,14 +57,17 @@ def logout(request):
     """
     token = request._auth
     token.delete()
-    return Response({'detail': 'Logout successful, Token succesfully deleted'}, status=status.HTTP_204_NO_CONTENT)
+    return Response(
+        {"detail": "Logout successful, Token succesfully deleted"},
+        status=status.HTTP_204_NO_CONTENT,
+    )
 
 
 class CustomObtainAuthToken(ObtainAuthToken):
     """API endpoint to obtain authorization tokens."""
 
-    login_response = openapi.Response('Login succesful', TokenSerializer)
-    login_failed_response = openapi.Response('Login failed')
+    login_response = openapi.Response("Login succesful", TokenSerializer)
+    login_failed_response = openapi.Response("Login failed")
 
     @swagger_auto_schema(responses={200: login_response, 400: login_failed_response})
     def post(self, request, *args, **kwargs):
@@ -81,15 +89,19 @@ class CustomObtainAuthToken(ObtainAuthToken):
         Response
             The response containing the token and other user data.
         """
-        serializer = self.serializer_class(data=request.data, context={'request': request})
+        serializer = self.serializer_class(
+            data=request.data, context={"request": request}
+        )
         serializer.is_valid(raise_exception=True)
-        user = serializer.validated_data['user']
+        user = serializer.validated_data["user"]
         token = Token.objects.create(user=user)
         return Response(TokenSerializer(token).data)
 
 
-@swagger_auto_schema(method='post', responses={200: valid_response, 401: invalid_response})
-@api_view(['POST'])
+@swagger_auto_schema(
+    method="post", responses={200: valid_response, 401: invalid_response}
+)
+@api_view(["POST"])
 @permission_classes((IsAuthenticated,))
 def validate_config_schema(request):
     """Validate a configuration yaml with using a schema
@@ -101,58 +113,81 @@ def validate_config_schema(request):
         or an 'output' with the output of the validator (config with defaults-autocomplete)
     """
     try:
-        config = yaml.safe_load(request.data['config'])
+        config = yaml.safe_load(request.data["config"])
     except yaml.YAMLError as e:
         error = e.__dict__
-        error['problem_mark'] = e.problem_mark.__dict__
-        del error['context_mark']
-        return Response({
-            'title': 'ERROR WHILE PARSING YAML STRING',
-            'error': error
-        })
-    schema = yaml.safe_load(request.data['schema'])
+        error["problem_mark"] = e.problem_mark.__dict__
+        del error["context_mark"]
+        return Response({"title": "ERROR WHILE PARSING YAML STRING", "error": error})
+    schema = yaml.safe_load(request.data["schema"])
     validator = DefaultingValidator(schema)
 
     try:
         output = validator.validate(config)
-        return Response({'title': 'None', "output": output})
+        return Response({"title": "None", "output": output})
     except jsonschema.exceptions.ValidationError as e:
         error = e.__dict__
         for key in error:
-            if(type(error[key]) == collections.deque):
+            if type(error[key]) == collections.deque:
                 error[key] = list(error[key])
 
-        return Response({
-            'title': 'INVALID CONFIG YAML',
-            'error': {
-                'message': str(error["message"]),
-                "path": [] if not error['path'] else list(error['path']),
-                "schema_path": [] if not error['schema_path'] else list(error['schema_path']),
+        return Response(
+            {
+                "title": "INVALID CONFIG YAML",
+                "error": {
+                    "message": str(error["message"]),
+                    "path": [] if not error["path"] else list(error["path"]),
+                    "schema_path": []
+                    if not error["schema_path"]
+                    else list(error["schema_path"]),
+                },
             }
-        })
+        )
 
 
-@swagger_auto_schema(method='post', responses={200: valid_response, 401: invalid_response})
-@api_view(['POST'])
+@swagger_auto_schema(
+    method="post", responses={200: valid_response, 401: invalid_response}
+)
+@api_view(["POST"])
 @permission_classes((IsAuthenticated,))
 def commander(request):
     """Sends a command to the LOVE-commander according to the received parameters
     """
     if not request.user.has_perm("api.command.execute_command"):
-        return Response({"ack": "User does not have permissions to execute commands."}, 401)
+        return Response(
+            {"ack": "User does not have permissions to execute commands."}, 401
+        )
     url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/cmd"
     response = requests.post(url, json=request.data)
 
     return Response(response.json(), status=response.status_code)
 
-@swagger_auto_schema(method='get', responses={200: valid_response, 401: invalid_response})
-@api_view(['GET'])
+
+@swagger_auto_schema(
+    method="get", responses={200: valid_response, 401: invalid_response}
+)
+@api_view(["GET"])
 @permission_classes((IsAuthenticated,))
 def salinfo_metadata(request):
     """Requests SalInfo.metadata from the commander containing a dict
      of <csc name>: { "sal_version": ..., "xml_version": ....}
     """
     url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/salinfo/metadata"
+    response = requests.get(url)
+
+    return Response(response.json(), status=response.status_code)
+
+
+@swagger_auto_schema(
+    method="get", responses={200: valid_response, 401: invalid_response}
+)
+@api_view(["GET"])
+@permission_classes((IsAuthenticated,))
+def salinfo_topic_names(request):
+    """Requests SalInfo.topic_names from the commander containing a dict
+     of <csc name>: { "command_names": [], "event_names": [], "telemetry_names": []}
+    """
+    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/salinfo/topic-names"
     response = requests.get(url)
 
     return Response(response.json(), status=response.status_code)


### PR DESCRIPTION
Add endpoint to get SAL topic names from LOVE-commander:
- Url: `salinfo/topic-names`
- Accepts query param `categories` that accepts a list of strings separated by dash characters. Eg: `salinfo/topic-names?categories=telemetry-event`
- Returns a dictionary indexed by IDL names, where each value is a dictionary with the topic names. Eg:

```
{
  ATDome: {
    command_names: [...],
    event_names: [...],
    telemetry_names: [...],
  },
  ATMCS: {
    command_names: [...],
    event_names: [...],
    telemetry_names: [...],
  },
}
```