### PR TITLE
Feature/commander topic data

### DIFF
--- a/manager/api/tests/test_commander.py
+++ b/manager/api/tests/test_commander.py
@@ -147,3 +147,65 @@ class SalinfoTestCase(TestCase):
         fakeport = "fakeport"
         expected_url = f"http://fakehost:fakeport/salinfo/topic-names"
         self.assertEqual(mock_requests.call_args, call(expected_url))
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.get")
+    def test_salinfo_topic_names_with_param(self, mock_requests, mock_environ):
+        """Test authorized user can get salinfo topic_names with query param"""
+        # Act:
+        url = reverse("salinfo-topic-names") + "?categories=telemetry"
+
+        with self.assertRaises(ValueError):
+            response = self.client.get(url)
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
+        expected_url = (
+            f"http://fakehost:fakeport/salinfo/topic-names?categories=telemetry"
+        )
+        self.assertEqual(mock_requests.call_args, call(expected_url))
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.get")
+    def test_salinfo_topic_data(self, mock_requests, mock_environ):
+        """Test authorized user can get salinfo topic_data"""
+        # Act:
+        url = reverse("salinfo-topic-data")
+
+        with self.assertRaises(ValueError):
+            response = self.client.get(url)
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
+        expected_url = f"http://fakehost:fakeport/salinfo/topic-data"
+        self.assertEqual(mock_requests.call_args, call(expected_url))
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.get")
+    def test_salinfo_topic_data_with_param(self, mock_requests, mock_environ):
+        """Test authorized user can get salinfo topic_data with query param"""
+        # Act:
+        url = reverse("salinfo-topic-data") + "?categories=telemetry"
+
+        with self.assertRaises(ValueError):
+            response = self.client.get(url)
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
+        expected_url = (
+            f"http://fakehost:fakeport/salinfo/topic-data?categories=telemetry"
+        )
+        self.assertEqual(mock_requests.call_args, call(expected_url))
+

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -39,5 +39,6 @@ urlpatterns = [
     path(
         "salinfo/topic-names", api.views.salinfo_topic_names, name="salinfo-topic-names"
     ),
+    path("salinfo/topic-data", api.views.salinfo_topic_data, name="salinfo-topic-data"),
 ]
 urlpatterns.append(path("", include(router.urls)))

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -187,7 +187,28 @@ def salinfo_topic_names(request):
     """Requests SalInfo.topic_names from the commander containing a dict
      of <csc name>: { "command_names": [], "event_names": [], "telemetry_names": []}
     """
-    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/salinfo/topic-names"
+    query = ""
+    if "categories" in request.query_params:
+        query = "?categories=" + request.query_params["categories"]
+    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/salinfo/topic-names{query}"
+    response = requests.get(url)
+
+    return Response(response.json(), status=response.status_code)
+
+
+@swagger_auto_schema(
+    method="get", responses={200: valid_response, 401: invalid_response}
+)
+@api_view(["GET"])
+@permission_classes((IsAuthenticated,))
+def salinfo_topic_data(request):
+    """Requests SalInfo.topic_data from the commander containing a dict
+     of <csc name>: { "command_data": [], "event_data": [], "telemetry_data": []}
+    """
+    query = ""
+    if "categories" in request.query_params:
+        query = "?categories=" + request.query_params["categories"]
+    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/salinfo/topic-data{query}"
     response = requests.get(url)
 
     return Response(response.json(), status=response.status_code)


### PR DESCRIPTION
Add endpoint to get SAL topic data from LOVE-commander:
- Url: `salinfo/topic-data`
- Accepts query param `categories` that accepts a list of strings separated by dash characters. Eg: `salinfo/topic-data?categories=telemetry-event`
- Returns a dictionary indexed by IDL names, where each value is a dictionary with the topic names. Eg:

```
{
    "ATDome": {
        "telemetry_data": {
            "position": {
                "dropoutDoorOpeningPercentage": {
                    "name": "dropoutDoorOpeningPercentage",
                    "description": "Current dropout shutter door opening percentage.",
                    "units": "unitless",
                    "type_name": "float"
                },
                "mainDoorOpeningPercentage": {
                    "name": "mainDoorOpeningPercentage",
                    "description": "Current main shutter door opening percentage.",
                    "units": "unitless",
                    "type_name": "float"
                },
                "azimuthPosition": {
                    "name": "azimuthPosition",
                    "description": "Current azimuth position.",
                    "units": "deg",
                    "type_name": "double"
                },
                "azimuthEncoderPosition": {
                    "name": "azimuthEncoderPosition",
                    "description": "Current azimuth encoder reading.",
                    "units": "unitless",
                    "type_name": "long long"
                }
            }
        },
        "command_data": {
            "abort": {
                "value": {
                    "name": "value",
                    "description": "Not used",
                    "units": "unitless",
                    "type_name": "boolean"
                }
            },
            "closeShutter": {
                "ignored": {
                    "name": "ignored",
                    "description": "This field is ignored.",
                    "units": "unitless",
                    "type_name": "boolean"
                }
            }
        },
        "event_data": {
            "allAxesInPosition": {
                "inPosition": {
                    "name": "inPosition",
                    "description": "In position?",
                    "units": "unitless",
                    "type_name": "boolean"
                },
                "priority": {
                    "name": "priority",
                    "description": "Priority code",
                    "units": "unitless",
                    "type_name": "long"
                }
            }
        }
    }
    "ATMCS": {
        "command_data": {...},
        "event_data": {...},
        "telemetry_data": {...},
    }
}
```