### PR TITLE
Feature/msg timestamps

### DIFF
--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -229,3 +229,8 @@ if AUTH_LDAP_SERVER_URI and not TESTING:
     AUTH_LDAP_USER_SEARCH = LDAPSearch(
         "ou=people,dc=planetexpress,dc=com", ldap.SCOPE_SUBTREE, "(uid=%(user)s)",
     )
+
+TRACE_TIMESTAMPS = True
+if os.environ.get("HIDE_TRACE_TIMESTAMPS", False):
+    TRACE_TIMESTAMPS = False
+

--- a/manager/pytest.ini
+++ b/manager/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = manager.settings
-HIDE_TRACE_TIMESTAMPS = True
 python_files = test_*.py tests_*.py tests.py
 env =
   TESTING=True
+  HIDE_TRACE_TIMESTAMPS = True

--- a/manager/pytest.ini
+++ b/manager/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = manager.settings
+HIDE_TRACE_TIMESTAMPS = True
 python_files = test_*.py tests_*.py tests.py
 env =
   TESTING=True

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -3,9 +3,10 @@ import json
 import random
 import asyncio
 import datetime
+from astropy.time import Time
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from manager.settings import PROCESS_CONNECTION_PASS
+from manager.settings import PROCESS_CONNECTION_PASS, TRACE_TIMESTAMPS
 from manager import utils
 from subscription.heartbeat_manager import HeartbeatManager
 
@@ -56,6 +57,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         message: `dict`
             dictionary containing the message parsed as json
         """
+        manager_rcv = Time.now().tai.datetime.timestamp() if TRACE_TIMESTAMPS else None
         if "option" in message:
             await self.handle_subscription_message(message)
         elif "action" in message:
@@ -63,7 +65,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         elif "heartbeat" in message:
             await self.handle_heartbeat_message(message)
         else:
-            await self.handle_data_message(message)
+            await self.handle_data_message(message, manager_rcv)
 
     async def handle_subscription_message(self, message):
         """Handle a subscription/unsubscription message.
@@ -177,7 +179,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         )
         self.heartbeat_manager.set_heartbeat_timestamp(message["heartbeat"], timestamp)
 
-    async def handle_data_message(self, message):
+    async def handle_data_message(self, message, manager_rcv):
         """Handle a data message.
 
         Sends the message to the corresponding groups based on the data of the message.
@@ -202,9 +204,11 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         data = message["data"]
         category = message["category"]
         user = self.scope["user"]
+        producer_snd = message["producer_snd"] if "producer_snd" in message else None
 
         # Store pairs of group, message to send:
         to_send = []
+        tracing = {}
 
         # Iterate over all stream groups
         for csc_message in data:
@@ -228,6 +232,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                     "data": {stream: data_csc[stream]},
                     "subscription": group_name,
                 }
+
                 to_send.append({"group": group_name, "message": msg})
                 streams_data[stream] = data_csc[stream]
 
@@ -247,6 +252,16 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         group_name = "{}-all-all-all".format(category)
         msg = {"type": "subscription_all_data", "category": category, "data": data}
         to_send.append({"group": group_name, "message": msg})
+
+        if TRACE_TIMESTAMPS:
+            tracing = {
+                "producer_snd": producer_snd,
+                "manager_rcv": manager_rcv,
+                "manager_snd": Time.now().tai.datetime.timestamp(),
+            }
+            for pair in to_send:
+                pair["message"]["tracing"] = tracing
+            print("to_send: ", to_send, flush=True)
 
         # Send all group-message pairs concurrently:
         await asyncio.gather(

--- a/manager/subscription/tests/test_subscriptions.py
+++ b/manager/subscription/tests/test_subscriptions.py
@@ -1,6 +1,7 @@
 """Tests for the subscription of consumers to streams."""
 import asyncio
 import pytest
+import os
 from django.contrib.auth.models import User, Permission
 from channels.testing import WebsocketCommunicator
 from manager.routing import application


### PR DESCRIPTION
Add timestamps in order to debug latency issues:
- Added to data messages of events and telemetries:
- Added the `tracing` key to the message with the following values in TAI seconds:
```
tracing: {
    producer_snd: <timestamp when the producer sent the message, in TAI seconds>,
    manager_rcv_from_producer: <timestamp when the manager receives the message from the producer>,
    manager_snd_to_group: <timestamp when the consumer sends the message to the group in the channel layer>,
    manager_rcv_from_group: <timestamp when the consumer receives the message from the group in the channel layer>,
    manager_snd_to_client: <timestamp when the manager sends the message to the clients>
}
```