### PR TITLE
Lovecsc http refactor

### DIFF
--- a/docsrc/source/modules/how_to_use_it.rst
+++ b/docsrc/source/modules/how_to_use_it.rst
@@ -65,7 +65,7 @@ Returns token, user data and permissions
 Validate token
 --------------
 Validates a given authorization token, passed through HTTP Headers.
-Returns a confirmation of validity, user data, permissions, server_time and (optionally) the LOVE configuraiton file.
+Returns a confirmation of validity, user data, permissions, server_time and (optionally) the LOVE configuration file.
 If the :code:`no_config` flag is added to the end of the URL, then the LOVE config files is not read and the corresponding value is returned as :code:`null`
 
 - Url: :code:`<IP>/manager/api/validate-token/` or :code:`<IP>/manager/api/validate-token/no_config/`
@@ -119,7 +119,7 @@ If the :code:`no_config` flag is added to the end of the URL, then the LOVE conf
 Swap token
 --------------
 Validates a given authorization token, passed through HTTP Headers.
-Returns a confirmation of validity, user data, permissions, server_time and (optionally) the LOVE configuraiton file.
+Returns a confirmation of validity, user data, permissions, server_time and (optionally) the LOVE configuration file.
 If the :code:`no_config` flag is added to the end of the URL, then the LOVE config files is not read and the corresponding value is returned as :code:`null`
 
 - Url: :code:`<IP>/manager/api/swap-token/` or :code:`<IP>/manager/api/swap-token/no_config/`

--- a/manager/api/tests/test_lovecsc.py
+++ b/manager/api/tests/test_lovecsc.py
@@ -39,12 +39,12 @@ class LOVECscTestCase(TestCase):
     )
     @patch("requests.post")
     def test_authorized_lovecsc_data(self, mock_requests, mock_environ):
-        """Test authorized user commander data is sent to love-commander"""
+        """Test authorized user observing log is sent to love-commander"""
         # Arrange:
         self.user.user_permissions.add(Permission.objects.get(name="Execute Commands"))
 
         # Act:
-        url = reverse("love-csc")
+        url = reverse("lovecsc-observinglog")
         data = {
             "user": "an user",
             "message": "a message",
@@ -52,9 +52,14 @@ class LOVECscTestCase(TestCase):
 
         with self.assertRaises(ValueError):
             response = self.client.post(url, data, format="json")
-        fakehostname = "fakehost"
-        fakeport = "fakeport"
-        expected_url = f"http://fakehost:fakeport/lovecsc"
+            result = response.json()
+
+        # self.assertEqual(response.status_code, 200)
+        # self.assertEqual(
+        #     result, {"ack": "Added new observing log to SAL."}
+        # )
+
+        expected_url = f"http://fakehost:fakeport/lovecsc/observinglog"
         self.assertEqual(mock_requests.call_args, call(expected_url, json=data))
 
     @patch(
@@ -67,12 +72,12 @@ class LOVECscTestCase(TestCase):
     def test_unauthorized_lovecsc(self, mock_requests, mock_environ):
         """Test an unauthorized user can't send commands"""
         # Act:
-        url = reverse("love-csc")
+        url = reverse("lovecsc-observinglog")
         data = {
             "user": "an user",
             "message": "a message",
         }
-
+        
         response = self.client.post(url, data, format="json")
         result = response.json()
 
@@ -80,3 +85,6 @@ class LOVECscTestCase(TestCase):
         self.assertEqual(
             result, {"ack": "User does not have permissions to send observing logs."}
         )
+
+        # expected_url = f"http://fakehost:fakeport/lovecsc/observinglog"
+        # self.assertEqual(mock_requests.call_args, call(expected_url, json=data))

--- a/manager/api/tests/test_lovecsc.py
+++ b/manager/api/tests/test_lovecsc.py
@@ -1,0 +1,82 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from api.models import Token
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User, Permission
+import yaml
+from unittest.mock import patch, call
+
+
+@override_settings(DEBUG=True)
+class LOVECscTestCase(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        """Define the test suite setup."""
+        # Arrange
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="an user",
+            password="password",
+            email="test@user.cl",
+            first_name="First",
+            last_name="Last",
+        )
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        self.user.user_permissions.add(
+            Permission.objects.get(codename="view_view"),
+            Permission.objects.get(codename="add_view"),
+            Permission.objects.get(codename="delete_view"),
+            Permission.objects.get(codename="change_view"),
+        )
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.post")
+    def test_authorized_lovecsc_data(self, mock_requests, mock_environ):
+        """Test authorized user commander data is sent to love-commander"""
+        # Arrange:
+        self.user.user_permissions.add(Permission.objects.get(name="Execute Commands"))
+
+        # Act:
+        url = reverse("love-csc")
+        data = {
+            "user": "an user",
+            "message": "a message",
+        }
+
+        with self.assertRaises(ValueError):
+            response = self.client.post(url, data, format="json")
+        fakehostname = "fakehost"
+        fakeport = "fakeport"
+        expected_url = f"http://fakehost:fakeport/lovecsc"
+        self.assertEqual(mock_requests.call_args, call(expected_url, json=data))
+
+    @patch(
+        "os.environ.get",
+        side_effect=lambda arg: "fakehost"
+        if arg == "COMMANDER_HOSTNAME"
+        else "fakeport",
+    )
+    @patch("requests.post")
+    def test_unauthorized_lovecsc(self, mock_requests, mock_environ):
+        """Test an unauthorized user can't send commands"""
+        # Act:
+        url = reverse("love-csc")
+        data = {
+            "user": "an user",
+            "message": "a message",
+        }
+
+        response = self.client.post(url, data, format="json")
+        result = response.json()
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            result, {"ack": "User does not have permissions to send observing logs."}
+        )

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
     ),
     path("auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("cmd/", api.views.commander, name="commander"),
+    path("lovecsc/", api.views.lovecsc, name="love-csc"),
     path("salinfo/metadata", api.views.salinfo_metadata, name="salinfo-metadata"),
     path(
         "salinfo/topic-names", api.views.salinfo_topic_names, name="salinfo-topic-names"

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -40,7 +40,7 @@ urlpatterns = [
     ),
     path("auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("cmd/", api.views.commander, name="commander"),
-    path("lovecsc/", api.views.lovecsc, name="love-csc"),
+    path("lovecsc/observinglog", api.views.lovecsc_observinglog, name="lovecsc-observinglog"),
     path("salinfo/metadata", api.views.salinfo_metadata, name="salinfo-metadata"),
     path(
         "salinfo/topic-names", api.views.salinfo_topic_names, name="salinfo-topic-names"

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -250,6 +250,40 @@ def commander(request):
 
 
 @swagger_auto_schema(
+    method="post",
+    responses={
+        200: openapi.Response("Observing log sent"),
+        400: openapi.Response("Missing parameters"),
+        401: openapi.Response("Unauthenticated"),
+        403: openapi.Response("Unauthorized"),
+    },
+)
+@api_view(["POST"])
+@permission_classes((IsAuthenticated,))
+def lovecsc(request):
+    """Sends an observing log message to the LOVE-commander according to the received parameters
+
+    Params
+    ------
+    request: Request
+        The Request object
+    
+    Returns
+    -------
+    Response
+        The response and status code of the request to the LOVE-Commander
+    """
+    if not request.user.has_perm("api.command.execute_command"):
+        return Response(
+            {"ack": "User does not have permissions to send observing logs."}, 401
+        )
+    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/lovecsc"
+    response = requests.post(url, json=request.data)
+
+    return Response(response.json(), status=response.status_code)
+
+
+@swagger_auto_schema(
     method="get",
     responses={
         200: openapi.Response(

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -260,7 +260,7 @@ def commander(request):
 )
 @api_view(["POST"])
 @permission_classes((IsAuthenticated,))
-def lovecsc(request):
+def lovecsc_observinglog(request):
     """Sends an observing log message to the LOVE-commander according to the received parameters
 
     Params
@@ -277,7 +277,7 @@ def lovecsc(request):
         return Response(
             {"ack": "User does not have permissions to send observing logs."}, 401
         )
-    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/lovecsc"
+    url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/lovecsc/observinglog"
     response = requests.post(url, json=request.data)
 
     return Response(response.json(), status=response.status_code)


### PR DESCRIPTION
This PR makes a refactor to the LOVE-manager in order to send observing logs from LOVE-frontend using HTTP connection instead of websocket connections.