### PR TITLE
Add new Dockerfile for only serving static files

### DIFF
--- a/Dockerfile-static
+++ b/Dockerfile-static
@@ -1,4 +1,4 @@
-FROM python:3.8.2-buster
+FROM python:3.8.2-buster as builder
 
 # Install required packages
 RUN apt-get update && \
@@ -26,6 +26,9 @@ RUN cp -u ui_framework/fixtures/thumbnails/* media/thumbnails
 RUN mkdir -p media/configs
 RUN cp -u api/fixtures/configs/* media/configs
 
-# Expose static files and port
+# copy compiled files to smaller image
+FROM alpine:3.8
+COPY --from=builder /usr/src/love/manager/static /usr/src/love/manager/static
+COPY --from=builder /usr/src/love/manager/media /usr/src/love/manager/media
 VOLUME /usr/src/love/manager/static
 VOLUME /usr/src/love/manager/media

--- a/Dockerfile-static
+++ b/Dockerfile-static
@@ -1,0 +1,25 @@
+FROM python:3.8.2-buster
+
+# Install required packages
+RUN apt-get update && \
+    apt-get install -y \
+    libsasl2-dev \
+    python-dev \
+    libldap2-dev \
+    libssl-dev &&\
+    rm -rf /var/lib/apt/lists/*
+
+# Set workdir and install python requirements
+WORKDIR /usr/src/love
+COPY manager/requirements.txt .
+RUN pip install -r requirements.txt
+
+# Copy source code and build project
+COPY manager ./manager
+WORKDIR /usr/src/love/manager
+RUN find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+RUN python manage.py collectstatic --noinput
+
+# Expose static files and port
+VOLUME /usr/src/love/manager/static
+VOLUME /usr/src/love/manager/media

--- a/Dockerfile-static
+++ b/Dockerfile-static
@@ -14,11 +14,17 @@ WORKDIR /usr/src/love
 COPY manager/requirements.txt .
 RUN pip install -r requirements.txt
 
-# Copy source code and build project
+# Copy source code and collect statics
 COPY manager ./manager
 WORKDIR /usr/src/love/manager
 RUN find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 RUN python manage.py collectstatic --noinput
+
+# Copy media data
+RUN mkdir -p media/thumbnails
+RUN cp -u ui_framework/fixtures/thumbnails/* media/thumbnails
+RUN mkdir -p media/configs
+RUN cp -u api/fixtures/configs/* media/configs
 
 # Expose static files and port
 VOLUME /usr/src/love/manager/static


### PR DESCRIPTION
This PR add a new Dockerfile for serving LOVE-manager static files. The folders with static files are:

- `/usr/usr/love/manager/static`
- `usr/src/love/manager/media`

Now the image doesn't run the server, collect static files and only mounts the related volumes.