### PR TITLE
Script logMessages is not compatible with the new Producer version

### DIFF
--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -258,3 +258,8 @@ Read from TRACE_TIMESTAMPS` environment variable (`bool`)"""
 
 if os.environ.get("HIDE_TRACE_TIMESTAMPS", False):
     TRACE_TIMESTAMPS = False
+
+
+# LOVE-CSC-PRODUCER
+"""Defines wether or not ussing the new LOVE-producer version, i.e. LOVE CSC Producer"""
+LOVE_CSC_PRODUCER = True

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -1,12 +1,14 @@
 """Contains the Django Channels Consumers that handle the reception/sending of channels messages."""
 import json
-import random
+
 import asyncio
 import datetime
 from astropy.time import Time
-from channels.db import database_sync_to_async
+
+# from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from django.conf import settings
+
 from manager import utils
 from subscription.heartbeat_manager import HeartbeatManager
 
@@ -143,8 +145,10 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                         "utc": "<current time in UTC scale as a unix timestamp (seconds)>",
                         "tai": "<current time in UTC scale as a unix timestamp (seconds)>",
                         "mjd": "<current time as a modified julian date>",
-                        "sidereal_summit": "<current time as a sidereal_time w/respect to the summit location (hourangles)>",
-                        "sidereal_summit": "<current time as a sidereal_time w/respect to Greenwich location (hourangles)>",
+                        "sidereal_summit": "<current time as a sidereal_time w/respect
+                                            to the summit location (hourangles)>",
+                        "sidereal_summit": "<current time as a sidereal_time w/respect
+                                            to Greenwich location (hourangles)>",
                         "tai_to_utc": "<The number of seconds of difference between TAI and UTC times (seconds)>",
                     },
                     "request_time": "<timestamp with the request time, e.g. 123243423.123>"
@@ -165,12 +169,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         if message["action"] == "get_time_data":
             request_time = message["request_time"]
             time_data = utils.get_times()
-            await self.send_json(
-                {
-                    "time_data": time_data,
-                    "request_time": request_time,
-                }
-            )
+            await self.send_json({"time_data": time_data, "request_time": request_time})
 
     async def handle_heartbeat_message(self, message):
         """Handle a heartbeat message.
@@ -316,7 +315,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         # If subscribing to an event, send the initial_state
         if category == "event":
             await self.channel_layer.group_send(
-                "initial_state-all-all-all",
+                f"initial_state-{csc}-all-all",
                 {
                     "type": "subscription_all_data",
                     "category": "initial_state",

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -172,6 +172,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
             time_data = utils.get_times()
             await self.send_json({"time_data": time_data, "request_time": request_time})
 
+    # DEPRECATED: now heartbeats are handled using SALobj events callbacks
     async def handle_heartbeat_message(self, message):
         """Handle a heartbeat message.
 

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -66,6 +66,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
             await self.handle_subscription_message(message)
         elif "action" in message:
             await self.handle_action_message(message)
+        # DEPRECATED: now heartbeats are received from event callbacks
         elif "heartbeat" in message:
             await self.handle_heartbeat_message(message)
         else:
@@ -226,6 +227,18 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                     }]
                 }
         """
+        # setting heartbeat
+        if message["data"][0]["csc"] == "Heartbeat":
+            heartbeat_message = message["data"][0]["data"]["stream"]
+            timestamp = (
+                heartbeat_message["last_heartbeat_timestamp"]
+                if "last_heartbeat_timestamp" in heartbeat_message
+                else datetime.datetime.now().timestamp()
+            )
+            self.heartbeat_manager.set_heartbeat_timestamp(
+                heartbeat_message["csc"], timestamp
+            )
+
         data = message["data"]
         category = message["category"]
         producer_snd = message["producer_snd"] if "producer_snd" in message else None

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -328,8 +328,9 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
 
         # If subscribing to an event, send the initial_state
         if category == "event":
+            csc_group_key = csc if settings.LOVE_CSC_PRODUCER else "all"
             await self.channel_layer.group_send(
-                f"initial_state-{csc}-all-all",
+                f"initial_state-{csc_group_key}-all-all",
                 {
                     "type": "subscription_all_data",
                     "category": "initial_state",


### PR DESCRIPTION
The new version of the LOVE-producer doesn't work properly with the Script CSC, as it uses dynamic salindexes. As the CSCSummary component works with specific CSC:salindex, this event logMessages is not received because there doesn't exists a LOVE-producer container for that specific CSC:salindex. This PR makes the necessary refactor.