### PR TITLE
Make heartbeats compliant with the new LOVE-producer

### DIFF
--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -1,12 +1,14 @@
 """Contains the Django Channels Consumers that handle the reception/sending of channels messages."""
 import json
-import random
-import asyncio
 import datetime
+
+import asyncio
 from astropy.time import Time
-from channels.db import database_sync_to_async
+
+# from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from django.conf import settings
+
 from manager import utils
 from subscription.heartbeat_manager import HeartbeatManager
 
@@ -60,12 +62,14 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         manager_rcv = (
             Time.now().tai.datetime.timestamp() if settings.TRACE_TIMESTAMPS else None
         )
+
         if "option" in message:
             await self.handle_subscription_message(message)
         elif "action" in message:
             await self.handle_action_message(message)
-        elif "heartbeat" in message:
-            await self.handle_heartbeat_message(message)
+        # DEPRECATED: now heartbeats are received from event callbacks
+        # elif "heartbeat" in message:
+        #     await self.handle_heartbeat_message(message)
         else:
             await self.handle_data_message(message, manager_rcv)
 
@@ -143,8 +147,10 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                         "utc": "<current time in UTC scale as a unix timestamp (seconds)>",
                         "tai": "<current time in UTC scale as a unix timestamp (seconds)>",
                         "mjd": "<current time as a modified julian date>",
-                        "sidereal_summit": "<current time as a sidereal_time w/respect to the summit location (hourangles)>",
-                        "sidereal_summit": "<current time as a sidereal_time w/respect to Greenwich location (hourangles)>",
+                        "sidereal_summit": "<current time as a sidereal_time w/respect
+                                            to the summit location (hourangles)>",
+                        "sidereal_summit": "<current time as a sidereal_time w/respect
+                                            to Greenwich location (hourangles)>",
                         "tai_to_utc": "<The number of seconds of difference between TAI and UTC times (seconds)>",
                     },
                     "request_time": "<timestamp with the request time, e.g. 123243423.123>"
@@ -165,13 +171,9 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         if message["action"] == "get_time_data":
             request_time = message["request_time"]
             time_data = utils.get_times()
-            await self.send_json(
-                {
-                    "time_data": time_data,
-                    "request_time": request_time,
-                }
-            )
+            await self.send_json({"time_data": time_data, "request_time": request_time})
 
+    # DEPRECATED: now heartbeats are received from event callbacks
     async def handle_heartbeat_message(self, message):
         """Handle a heartbeat message.
 
@@ -190,11 +192,11 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                 }
         """
         timestamp = (
-            message["timestamp"]
-            if "timestamp" in message
+            message["last_heartbeat_timestamp"]
+            if "last_heartbeat_timestamp" in message
             else datetime.datetime.now().timestamp()
         )
-        self.heartbeat_manager.set_heartbeat_timestamp(message["heartbeat"], timestamp)
+        self.heartbeat_manager.set_heartbeat_timestamp(message["csc"], timestamp)
 
     async def handle_data_message(self, message, manager_rcv):
         """Handle a data message.
@@ -227,6 +229,10 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
                     }]
                 }
         """
+        # setting heartbeat
+        if message["data"][0]["csc"] == "Heartbeat":
+            self.handle_heartbeat_message(message["data"][0]["data"]["stream"])
+
         data = message["data"]
         category = message["category"]
         producer_snd = message["producer_snd"] if "producer_snd" in message else None
@@ -316,7 +322,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
         # If subscribing to an event, send the initial_state
         if category == "event":
             await self.channel_layer.group_send(
-                "initial_state-all-all-all",
+                f"initial_state-all-all-all",
                 {
                     "type": "subscription_all_data",
                     "category": "initial_state",


### PR DESCRIPTION
As the LOVE-producer configuration was changed to only run one remote per producer-container, the heartbeat monitor component has to be changed to receive the statuses of the different CSC-producers, i.e. ATDome:0, ATMCS:0, Scriptqueue:1, etc.

This PR makes some changes that ensures compatibility with the new way in which heartbeats are produced.