### PR TITLE
Environment variable set for LOVE_CSC_PRODUCER

### DIFF
--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -260,4 +260,4 @@ if os.environ.get("HIDE_TRACE_TIMESTAMPS", False):
 
 # LOVE-CSC-PRODUCER
 """Defines wether or not ussing the new LOVE-producer version, i.e. LOVE CSC Producer"""
-LOVE_CSC_PRODUCER = True
+LOVE_CSC_PRODUCER = os.environ.get("LOVE_CSC_PRODUCER", False)


### PR DESCRIPTION
This PR makes a hotfix for a previous change which introduced the LOVE_CSC_PRODUCER variable to control whether using the old or new version of the LOVE-producer 