### PR TITLE
Document LOVE-producer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All these variables are initialized with default variables defined in :code:`.en
 - `DB_HOST`: defines the host of the Database. Only used if `DB_ENGINE=postgresql`.
 - `DB_PORT`: defines the port of the Database. Only used if `DB_ENGINE=postgresql`.
 - `NO_DEBUG`: defines wether or not the LOVE-.manager will be run using Django's debug mode. If the variable is defined, then Debug mode will be off.
-- `LOVE_CSC_PRODUCER`: defines wether or not ussing the new LOVE-producer version which uses the CSC Client.
+- `LOVE_PRODUCER_LEGACY`: defines wether or not ussing the legacy LOVE-producer version, i.e. not the LOVE CSC Producer. If the variable is defined, then the CSC Client won't be used.
 - `SECRET_KEY`: overrides Django's SECRET_KEY, if not defined the default value (public in this repo) will be used.
 - `AUTH_LDAP_SERVER_URI`: (deprecated) the location of the LDAP authentication server. No LDAP server is used if this variable is empty
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All these variables are initialized with default variables defined in :code:`.en
 - `DB_HOST`: defines the host of the Database. Only used if `DB_ENGINE=postgresql`.
 - `DB_PORT`: defines the port of the Database. Only used if `DB_ENGINE=postgresql`.
 - `NO_DEBUG`: defines wether or not the LOVE-.manager will be run using Django's debug mode. If the variable is defined, then Debug mode will be off.
-- `LOVE_PRODUCER_LEGACY`: defines wether or not ussing the legacy LOVE-producer version, i.e. not the LOVE CSC Producer. If the variable is defined, then the CSC Client won't be used.
+- `LOVE_PRODUCER_LEGACY`: defines wether or not ussing the legacy LOVE-producer version. If the variable is defined, then the CSC Client won't be used and the legacy version will.
 - `SECRET_KEY`: overrides Django's SECRET_KEY, if not defined the default value (public in this repo) will be used.
 - `AUTH_LDAP_SERVER_URI`: (deprecated) the location of the LDAP authentication server. No LDAP server is used if this variable is empty
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All these variables are initialized with default variables defined in :code:`.en
 - `DB_HOST`: defines the host of the Database. Only used if `DB_ENGINE=postgresql`.
 - `DB_PORT`: defines the port of the Database. Only used if `DB_ENGINE=postgresql`.
 - `NO_DEBUG`: defines wether or not the LOVE-.manager will be run using Django's debug mode. If the variable is defined, then Debug mode will be off.
+- `LOVE_CSC_PRODUCER`: defines wether or not ussing the new LOVE-producer version which uses the CSC Client.
 - `SECRET_KEY`: overrides Django's SECRET_KEY, if not defined the default value (public in this repo) will be used.
 - `AUTH_LDAP_SERVER_URI`: (deprecated) the location of the LDAP authentication server. No LDAP server is used if this variable is empty
 

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -260,4 +260,4 @@ if os.environ.get("HIDE_TRACE_TIMESTAMPS", False):
 
 # LOVE-CSC-PRODUCER
 """Defines wether or not ussing the new LOVE-producer version, i.e. LOVE CSC Producer"""
-LOVE_CSC_PRODUCER = os.environ.get("LOVE_CSC_PRODUCER", False)
+LOVE_CSC_PRODUCER = os.environ.get("LOVE_CSC_PRODUCER", True)

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -258,6 +258,6 @@ if os.environ.get("HIDE_TRACE_TIMESTAMPS", False):
     TRACE_TIMESTAMPS = False
 
 
-# LOVE-CSC-PRODUCER
-"""Defines wether or not ussing the new LOVE-producer version, i.e. LOVE CSC Producer"""
-LOVE_CSC_PRODUCER = os.environ.get("LOVE_CSC_PRODUCER", True)
+# LOVE-PRODUCER-CONFIGURATION
+"""Defines wether or not ussing the legacy LOVE-producer version, i.e. not the LOVE CSC Producer"""
+LOVE_PRODUCER_LEGACY = os.environ.get("LOVE_PRODUCER_LEGACY", False)

--- a/manager/subscription/consumers.py
+++ b/manager/subscription/consumers.py
@@ -328,7 +328,7 @@ class SubscriptionConsumer(AsyncJsonWebsocketConsumer):
 
         # If subscribing to an event, send the initial_state
         if category == "event":
-            csc_group_key = csc if settings.LOVE_CSC_PRODUCER else "all"
+            csc_group_key = csc if not settings.LOVE_PRODUCER_LEGACY else "all"
             await self.channel_layer.group_send(
                 f"initial_state-{csc_group_key}-all-all",
                 {


### PR DESCRIPTION
As the LOVE-producer has two ways to being executed (using the CSC client or not). We had to document the necessary configuration to deploy each of the instances. As the LOVE-manager connects with the LOVE-producer it also has to include this configuration.