### PR TITLE
Allow manager to route traffic to different manager instances.

### DIFF
--- a/manager/subscription/routing.py
+++ b/manager/subscription/routing.py
@@ -5,7 +5,7 @@ from .consumers import SubscriptionConsumer
 
 websocket_urlpatterns = [
     url(
-        "^manager/ws/subscription/?$",
+        r"^manager(.*?)/ws/subscription/?$",
         TokenAuthMiddleware(SubscriptionConsumer.as_asgi()),
     ),
 ]


### PR DESCRIPTION
This minor update allows us to scale the manager horizontally, spinning up multiple managers to deal with the traffic from one or more producers. I will file a ticket to LOVE-integration-tools with the updates for horizontal scaling. I tested this at the summit and it seems to work really well. 