### PR TITLE
 Bump pillow from 8.3.2 to 9.0.0 in /manager #136 

### DIFF
--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -48,6 +48,7 @@ msgpack==1.0.0
 numpy==1.18.1
 packaging==20.3
 pip-licenses==2.1.1
+Pillow==9.0.0
 pluggy==0.13.1
 psycopg2==2.8.4
 py==1.10.0

--- a/manager/requirements_no_version.txt
+++ b/manager/requirements_no_version.txt
@@ -47,6 +47,7 @@ more-itertools
 msgpack
 numpy
 packaging
+Pillow
 pluggy
 psycopg2
 py


### PR DESCRIPTION
This PR is a fix of the previous PR as it removed the Pillow library. At beginning we thought this library was not used, but is part of the Django database module. As it is neccesary we added it again with the respective version upgrade.