### PR TITLE
Upgrade to astropy 5.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,5 @@ webpack-stats.*
 **/__pycache__
 **/.DS_Store
 **/db_data
-
-# preserve folder structure with dummy gitinclude file
-manager/config/**
-!manager/config/.gitinclude
-manager/media/thumbnails/**
-!manager/media/thumbnails/.gitinclude
-manager/ui_framework/tests/media/thumbnails/**
-!manager/ui_framework/tests/media/thumbnails/.gitinclude
+**/media/configs
+**/media/thumbnails

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
           branch "bugfix/*"
           branch "hotfix/*"
           branch "release/*"
+          branch "tickets/*"
           branch "PR-*"
         }
       }

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,2 +1,0 @@
-**/__pycache__
-**/db_data

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -2,7 +2,7 @@ aioredis==1.3.1
 alabaster==0.7.12
 asgiref==3.3.1
 asn1crypto==1.3.0
-astropy==4.0
+astropy==5.0.3
 async-timeout==3.0.1
 atomicwrites==1.3.0
 attrs==19.3.0

--- a/manager/ui_framework/tests/tests_models.py
+++ b/manager/ui_framework/tests/tests_models.py
@@ -385,7 +385,7 @@ class WorkspaceViewModelTestCase(TestCase):
             "The number of objects in the DB have decreased by 1",
         )
         with self.assertRaises(Exception):
-            Workspace.objects.get(pk=self.workspace_view_pk)
+            WorkspaceView.objects.get(pk=self.workspace_view_pk)
 
 
 class WorkspaceAndViewsRelationsTestCase(TestCase):


### PR DESCRIPTION
This PR upgrades the astropy library to use version `5.0.3`. There were some errors because of the outdated astropy `4.0`, with the upgrade the errors disappeared.