### PR TITLE
Update dependencies

### DIFF
--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -42,7 +42,7 @@ jsonschema==3.2.0
 m2r==0.2.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
-mistune==0.8.4
+mistune<2.0.0
 more-itertools==8.2.0
 msgpack==1.0.0
 numpy==1.22.0


### PR DESCRIPTION
This PR updates `requirements.txt` `mistune` packages to avoid errors with `m2r` when using `mistune >= 2.0.0`.