### PR TITLE
Refactor Authorize CSC connection

### DIFF
--- a/manager/api/tests/test_authlist.py
+++ b/manager/api/tests/test_authlist.py
@@ -1,3 +1,5 @@
+import requests
+from unittest.mock import patch
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from api.models import Token, CSCAuthorizationRequest
@@ -127,7 +129,16 @@ class AuthlistTestCase(TestCase):
             "message": "This will last for 30 minutes.",
             "duration": 30,
         }
+        mock_patcher = patch("requests.post")
+        mock_client = mock_patcher.start()
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response.json = lambda: {"ack": "Command sent."}
+        mock_client.return_value = mock_response
+
         response = self.client.post(url, payload, format="json")
+
+        mock_client.stop()
 
         # Assert
         self.assertEqual(response.status_code, 201)

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -848,17 +848,18 @@ class CSCAuthorizationRequestViewSet(
             or authorization_obj.unauthorized_cscs != ""
         ):
             authorization_obj.save()
+            created_authorizations.append(authorization_obj)
+
             if authorization_obj.status == "Authorized":
                 query_authorize_csc(
                     CSCAuthorizationRequestSerializer(authorization_obj).data
                 )
-            created_authorizations.append(authorization_obj)
 
-            if authorization_obj.duration and int(authorization_obj.duration) > 0:
-                authlist_revert_authorization_task(
-                    CSCAuthorizationRequestSerializer(authorization_obj).data,
-                    schedule=int(authorization_obj.duration) * 60,
-                )
+                if authorization_obj.duration and int(authorization_obj.duration) > 0:
+                    authlist_revert_authorization_task(
+                        CSCAuthorizationRequestSerializer(authorization_obj).data,
+                        schedule=(int(authorization_obj.duration) * 60) - 5,
+                    )
 
         if len(created_authorizations) > 0:
             return Response(
@@ -892,7 +893,7 @@ class CSCAuthorizationRequestViewSet(
             if updated_instance.duration and int(updated_instance.duration) > 0:
                 authlist_revert_authorization_task(
                     CSCAuthorizationRequestSerializer(updated_instance).data,
-                    schedule=int(updated_instance.duration) * 60,
+                    schedule=(int(updated_instance.duration) * 60) - 5,
                 )
 
             return Response(


### PR DESCRIPTION
This PR refactors the code to connect to the Authorize CSC using the LOVE-commander endpoint for commands. Now the LOVE-manager will send the `requestAuthorization` command to the Authorize CSC for any accepted authorization request.