### PR TITLE
Upgrade pytest dependencies

### DIFF
--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -61,10 +61,10 @@ Pygments==2.7.4
 PyHamcrest==2.0.2
 pyparsing==2.4.6
 pyrsistent==0.15.7
-pytest==5.3.5
-pytest-asyncio==0.10.0
-pytest-django==3.8.0
-pytest-env==0.6.2
+pytest==7.2.0
+pytest-asyncio==0.20.3
+pytest-django==4.5.2
+pytest-env==0.8.1
 python-dateutil==2.8.1
 python-ldap==3.4.0
 pytz==2019.3


### PR DESCRIPTION
This PR makes some upgrades to pytest libraries in order to solve security issues regarding the following alert: https://github.com/lsst-ts/LOVE-manager/security/dependabot/14.