### PR TITLE
Remove py library as it is not used anymore after pytest upgrade

### DIFF
--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -51,7 +51,6 @@ pip-licenses==2.1.1
 Pillow==9.3.0
 pluggy==0.13.1
 psycopg2==2.8.4
-py==1.10.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.5.0


### PR DESCRIPTION
Remove `py` library.