### PR TITLE
Extend UI Framework permissions to normal users

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
         exclude: conda/meta.yaml
 
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.12.0
     hooks:
       - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/manager/api/admin.py
+++ b/manager/api/admin.py
@@ -11,8 +11,11 @@ from api.models import Token
 from api.models import ConfigFile, EmergencyContact
 from api.models import CSCAuthorizationRequest
 
+# from django.contrib.auth.models import Permission
+
 
 admin.site.register(Token)
 admin.site.register(ConfigFile)
 admin.site.register(EmergencyContact)
 admin.site.register(CSCAuthorizationRequest)
+# admin.site.register(Permission)

--- a/manager/api/management/commands/createusers.py
+++ b/manager/api/management/commands/createusers.py
@@ -10,6 +10,7 @@ cmd_user_username = "cmd_user"
 admin_username = "admin"
 authlist_username = "authlist_user"
 cmd_groupname = "cmd"
+ui_framework_groupname = "ui_framework"
 authlist_groupname = "authlist"
 
 
@@ -47,9 +48,11 @@ class Command(BaseCommand):
 
     It also creates 2 Group:
     "cmd_group", which defines the commands execution permissions.
+    "ui_framework_group", which defines the permissions to add, edit and delete views.
     "authlist_group", which defines the permission to access and resolve AuthList requests
 
     "cmd_user" and "test" users belong to "cmd_group".
+    "cmd_user", "test" and "authlist_user" users belong to "ui_framework_group".
     "authlist_user" belong to "authlist_group"."""
 
     requires_migrations_checks = True
@@ -128,9 +131,17 @@ class Command(BaseCommand):
         # Create cmd_group
         cmd_group = self._create_cmd_group()
 
-        # Add cmd_user to cmd_group
+        # Add cmd_user and test users to cmd_group
         cmd_group.user_set.add(cmd_user)
         cmd_group.user_set.add(test_user)
+
+        # Create ui_framework group
+        ui_framework_group = self._create_ui_framework_group()
+
+        # Add cmd_user, test and authlist_user users to ui_framework_group
+        ui_framework_group.user_set.add(cmd_user)
+        ui_framework_group.user_set.add(test_user)
+        ui_framework_group.user_set.add(authlist_user)
 
         # Create authlist_group
         authlist_group = self._create_authlist_group()
@@ -183,6 +194,22 @@ class Command(BaseCommand):
         """
         group, created = Group.objects.get_or_create(name=cmd_groupname)
         permissions = Permission.objects.filter(codename="command.execute_command")
+        for permission in permissions:
+            group.permissions.add(permission)
+        return group
+
+    def _create_ui_framework_group(self):
+        """Create and return the group of users with permissions to save, edit and delete views.
+
+        Returns
+        -------
+        grouop: Group
+            The Group object
+        """
+        group, created = Group.objects.get_or_create(name=ui_framework_groupname)
+        permissions = Permission.objects.filter(
+            content_type__app_label__contains="ui_framework"
+        )
         for permission in permissions:
             group.permissions.add(permission)
         return group

--- a/manager/api/management/commands/tests.py
+++ b/manager/api/management/commands/tests.py
@@ -34,7 +34,7 @@ class CreateusersTestCase(TestCase):
             User.objects.count(), old_users_num + 5, "There are no new users"
         )
         self.assertEqual(
-            Group.objects.count(), old_groups_num + 2, "There is no new group"
+            Group.objects.count(), old_groups_num + 3, "There is no new group"
         )
         admin = User.objects.filter(username=admin_username).first()
         user = User.objects.filter(username=user_username).first()
@@ -89,7 +89,7 @@ class CreateusersTestCase(TestCase):
         command.handle(*[], **options)
         # Assert:
         self.assertEqual(
-            Group.objects.count(), old_groups_num + 2, "There is no new group"
+            Group.objects.count(), old_groups_num + 3, "There is no new group"
         )
         admin = User.objects.filter(username=admin_username).first()
         user = User.objects.filter(username=user_username).first()

--- a/manager/api/tests/test_configfile.py
+++ b/manager/api/tests/test_configfile.py
@@ -1,18 +1,12 @@
 """Test users' authentication through the API."""
-import datetime
-import io
 import json
 from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth.models import User, Permission
-from freezegun import freeze_time
+from django.contrib.auth.models import User
 from rest_framework.test import APIClient
-from rest_framework import status
 from api.models import ConfigFile, Token
 from django.conf import settings
-from manager import utils
 from django.core.files.base import ContentFile
-from django.conf import settings
 import tempfile
 
 # python manage.py test api.tests.tests_configfile.ConfigFileApiTestCase

--- a/manager/api/tests/test_emergencycontact.py
+++ b/manager/api/tests/test_emergencycontact.py
@@ -1,16 +1,10 @@
 """Test users' authentication through the API."""
-import datetime
-import io
 import json
 from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth.models import User, Permission
-from freezegun import freeze_time
+from django.contrib.auth.models import User
 from rest_framework.test import APIClient
-from rest_framework import status
 from api.models import EmergencyContact, Token
-from django.conf import settings
-from manager import utils
 from django.core.files.base import ContentFile
 
 # python manage.py test api.tests.tests_emergencycontact.EmergencyContactApiTestCase

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -217,7 +217,9 @@ class CustomObtainAuthToken(ObtainAuthToken):
                     cmd_group.user_set.add(user_obj)
                     ui_framework_group.user_set.add(user_obj)
             except Exception:
-                data = {"detail": "Login failed, add cmd permission error."}
+                data = {
+                    "detail": "Login failed, add cmd and ui_framework permissions error."
+                }
                 return Response(data, status=400)
 
         token = Token.objects.create(user=user_obj)
@@ -289,10 +291,16 @@ class CustomSwapAuthToken(ObtainAuthToken):
                     map(lambda u: u.decode(), ldap_result[0][1]["memberUid"])
                 )
                 if username in ops_users:
-                    group = Group.objects.filter(name="cmd").first()
-                    group.user_set.add(user_obj)
+                    cmd_group = Group.objects.filter(name="cmd").first()
+                    ui_framework_group = Group.objects.filter(
+                        name="ui_framework"
+                    ).first()
+                    cmd_group.user_set.add(user_obj)
+                    ui_framework_group.user_set.add(user_obj)
             except Exception:
-                data = {"detail": "Login failed, add cmd permission error."}
+                data = {
+                    "detail": "Login failed, add cmd and ui_framework permissions error."
+                }
                 return Response(data, status=400)
 
         token = Token.objects.create(user=user_obj)

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -210,8 +210,12 @@ class CustomObtainAuthToken(ObtainAuthToken):
                     map(lambda u: u.decode(), ldap_result[0][1]["memberUid"])
                 )
                 if username in ops_users:
-                    group = Group.objects.filter(name="cmd").first()
-                    group.user_set.add(user_obj)
+                    cmd_group = Group.objects.filter(name="cmd").first()
+                    ui_framework_group = Group.objects.filter(
+                        name="ui_framework"
+                    ).first()
+                    cmd_group.user_set.add(user_obj)
+                    ui_framework_group.user_set.add(user_obj)
             except Exception:
                 data = {"detail": "Login failed, add cmd permission error."}
                 return Response(data, status=400)


### PR DESCRIPTION
Permissions to add, edit or delete views from LOVE were given only for the admin user. This PR adds a new group of permissions with respect to the UI Framework access. Now users cmd_user, test and authlist_user have the described permissions.

Also users who login with IPA credentials and belongs to the love_ops group, will also be part of this group of permissions.

Also `black`and `flake8` versions of pre-commit hook were updated.