### PR TITLE
Fix file handling on RemoteStorage class

### DIFF
--- a/manager/api/fixtures/initial_data_remote_inria.json
+++ b/manager/api/fixtures/initial_data_remote_inria.json
@@ -7,7 +7,7 @@
       "update_timestamp": "2020-12-29T14:21:31.040Z",
       "user": 1,
       "file_name": "default.json",
-      "config_file": "http://localhost/media/configs/default.json"
+      "config_file": "http://love-nginx-mount/media/configs/default.json"
     }
   },
   {

--- a/manager/api/tests/test_configfile.py
+++ b/manager/api/tests/test_configfile.py
@@ -1,13 +1,16 @@
 """Test users' authentication through the API."""
 import json
-from django.test import TestCase
+import requests
+import tempfile
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib.auth.models import User
 from rest_framework.test import APIClient
 from api.models import ConfigFile, Token
 from django.conf import settings
 from django.core.files.base import ContentFile
-import tempfile
+from unittest import mock
+
 
 # python manage.py test api.tests.tests_configfile.ConfigFileApiTestCase
 
@@ -36,42 +39,73 @@ class ConfigFileApiTestCase(TestCase):
             first_name="First",
             last_name="Last",
         )
-        self.filename = "test.json"
-        self.content = {"key1": "this is the content of the file"}
-        self.configfile = ConfigFile.objects.create(
+        self.token = Token.objects.create(user=self.user)
+        self.url = reverse("config")
+
+        self.local_config_file_content = {
+            "key1": "this is the content of the local file"
+        }
+        self.local_config_file = ConfigFile.objects.create(
             user=self.user,
             config_file=ConfigFileApiTestCase.get_config_file_sample(
-                "random_filename", self.content
+                "random_local_filename.json",
+                self.local_config_file_content,
             ),
-            file_name=self.filename,
+            file_name="random_local_filename.json",
         )
-        self.url = reverse("config")
-        self.token = Token.objects.create(user=self.user)
+
+        self.remote_config_file_content = {
+            "key1": "this is the content of the remote file"
+        }
+        self.remote_config_file = ConfigFile.objects.create(
+            user=self.user,
+            config_file=ConfigFileApiTestCase.get_config_file_sample(
+                "http://foo.bar/LOVE/CONFIG/random_remote_filename.json",
+                self.remote_config_file_content,
+            ),
+            file_name="random_remote_filename.json",
+        )
+        # Need to overwrite config file name to match the one in the remote server
+        self.remote_config_file.config_file.name = (
+            self.remote_config_file.config_file.name.replace("configs/", "")
+        )
+        self.remote_config_file.save()
 
     def test_get_config_files_list(self):
         """Test that an authenticated user can get a config file."""
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("configfile-list"), format="json")
         self.assertEqual(response.status_code, 200)
-        expected_data = {
-            "id": self.configfile.id,
-            "username": self.user.username,
-            "filename": self.filename,
-        }
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["filename"], expected_data["filename"])
+        # Querying the configfile-list endpoints
+        # retrieves the list of config files in descending timestamp order
+        expected_data = [
+            {
+                "id": self.remote_config_file.id,
+                "username": self.user.username,
+                "filename": self.remote_config_file.file_name,
+            },
+            {
+                "id": self.local_config_file.id,
+                "username": self.user.username,
+                "filename": self.local_config_file.file_name,
+            },
+        ]
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["filename"], expected_data[0]["filename"])
+        self.assertEqual(response.data[1]["filename"], expected_data[1]["filename"])
 
     def test_get_config_file(self):
         """Test that an authenticated user can get a config file."""
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(
-            reverse("configfile-detail", args=[self.configfile.id]), format="json"
+            reverse("configfile-detail", args=[self.local_config_file.id]),
+            format="json",
         )
         self.assertEqual(response.status_code, 200)
         expected_data = {
-            "id": self.configfile.id,
+            "id": self.local_config_file.id,
             "username": self.user.username,
-            "filename": self.filename,
+            "filename": self.local_config_file.file_name,
         }
         self.assertEqual(response.data["id"], expected_data["id"])
         self.assertEqual(response.data["username"], expected_data["username"])
@@ -81,17 +115,45 @@ class ConfigFileApiTestCase(TestCase):
         """Test that an authenticated user can get a config file content."""
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(
-            reverse("configfile-content", args=[self.configfile.id]), format="json"
+            reverse("configfile-content", args=[self.local_config_file.id]),
+            format="json",
         )
         self.assertEqual(response.status_code, 200)
         expected_data = {
-            "id": self.configfile.id,
-            "content": self.content,
-            "filename": self.filename,
+            "id": self.local_config_file.id,
+            "content": self.local_config_file_content,
+            "filename": self.local_config_file.file_name,
         }
         self.assertEqual(response.data["id"], expected_data["id"])
         self.assertEqual(response.data["content"], expected_data["content"])
         self.assertEqual(response.data["filename"], expected_data["filename"])
+
+    @override_settings(DEFAULT_FILE_STORAGE="manager.utils.RemoteStorage")
+    def test_get_config_file_content_with_remote_storage(self):
+        """Test that an authenticated user can get a config file content."""
+        mock_requests_get = mock.patch("requests.get")
+        mock_requests_get_client = mock_requests_get.start()
+        response_requests_get = requests.Response()
+        response_requests_get.status_code = 200
+        response_requests_get.json = lambda: self.remote_config_file_content
+        mock_requests_get_client.return_value = response_requests_get
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        response = self.client.get(
+            reverse("configfile-content", args=[self.remote_config_file.id]),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        expected_data = {
+            "id": self.remote_config_file.id,
+            "content": self.remote_config_file_content,
+            "filename": self.remote_config_file.file_name,
+        }
+        self.assertEqual(response.data["id"], expected_data["id"])
+        self.assertEqual(response.data["content"], expected_data["content"])
+        self.assertEqual(response.data["filename"], expected_data["filename"])
+
+        mock_requests_get.stop()
 
     def test_unauthenticated_cannot_get_config_file(self):
         """Test that an unauthenticated user cannot get the config file."""

--- a/manager/api/tests/test_configfile.py
+++ b/manager/api/tests/test_configfile.py
@@ -42,34 +42,83 @@ class ConfigFileApiTestCase(TestCase):
         self.token = Token.objects.create(user=self.user)
         self.url = reverse("config")
 
+        # Local config file
         self.local_config_file_content = {
             "key1": "this is the content of the local file"
         }
         self.local_config_file = ConfigFile.objects.create(
             user=self.user,
             config_file=ConfigFileApiTestCase.get_config_file_sample(
-                "random_local_filename.json",
+                "local_filename.json",
                 self.local_config_file_content,
             ),
-            file_name="random_local_filename.json",
+            file_name="local_filename",
         )
 
+        # Remote config file
         self.remote_config_file_content = {
             "key1": "this is the content of the remote file"
         }
         self.remote_config_file = ConfigFile.objects.create(
             user=self.user,
             config_file=ConfigFileApiTestCase.get_config_file_sample(
-                "http://foo.bar/LOVE/CONFIG/random_remote_filename.json",
+                "http://foo.bar.lsst.org/bucket/LOVE/CONFIG/remote_filename.json",
                 self.remote_config_file_content,
             ),
-            file_name="random_remote_filename.json",
+            file_name="remote_filename",
         )
         # Need to overwrite config file name to match the one in the remote server
         self.remote_config_file.config_file.name = (
             self.remote_config_file.config_file.name.replace("configs/", "")
         )
         self.remote_config_file.save()
+
+        # Remote config file with invalid URL
+        self.remote_config_file_invalid_url = ConfigFile.objects.create(
+            user=self.user,
+            config_file=ConfigFileApiTestCase.get_config_file_sample(
+                "http://foo.bar/remote_filename.json",
+                self.remote_config_file_content,
+            ),
+            file_name="remote_filename_invalid_url",
+        )
+        # Need to overwrite config file name to match the one in the remote server
+        self.remote_config_file_invalid_url.config_file.name = (
+            self.remote_config_file_invalid_url.config_file.name.replace("configs/", "")
+        )
+        self.remote_config_file_invalid_url.save()
+
+        # Remote config file not found
+        self.remote_config_file_not_found = ConfigFile.objects.create(
+            user=self.user,
+            config_file=ConfigFileApiTestCase.get_config_file_sample(
+                "http://foo.bar.lsst.org/bucket/LOVE/CONFIG/remote_filename_not_found.json",
+                self.remote_config_file_content,
+            ),
+            file_name="remote_filename_not_found",
+        )
+        # Need to overwrite config file name to match the one in the remote server
+        self.remote_config_file_not_found.config_file.name = (
+            self.remote_config_file_not_found.config_file.name.replace("configs/", "")
+        )
+        self.remote_config_file_not_found.save()
+
+        # Remote config file with type not allowed
+        self.remote_config_file_type_not_allowed = ConfigFile.objects.create(
+            user=self.user,
+            config_file=ConfigFileApiTestCase.get_config_file_sample(
+                "http://foo.bar.lsst.org/bucket/LOVE/CONFIG/remote_filename.json",
+                self.remote_config_file_content,
+            ),
+            file_name="remote_filename_type_notallow",
+        )
+        # Need to overwrite config file name to match the one in the remote server
+        self.remote_config_file_type_not_allowed.config_file.name = (
+            self.remote_config_file_type_not_allowed.config_file.name.replace(
+                "configs/", ""
+            )
+        )
+        self.remote_config_file_type_not_allowed.save()
 
     def test_get_config_files_list(self):
         """Test that an authenticated user can get a config file."""
@@ -79,6 +128,21 @@ class ConfigFileApiTestCase(TestCase):
         # Querying the configfile-list endpoints
         # retrieves the list of config files in descending timestamp order
         expected_data = [
+            {
+                "id": self.remote_config_file_type_not_allowed.id,
+                "username": self.user.username,
+                "filename": self.remote_config_file_type_not_allowed.file_name,
+            },
+            {
+                "id": self.remote_config_file_not_found.id,
+                "username": self.user.username,
+                "filename": self.remote_config_file_not_found.file_name,
+            },
+            {
+                "id": self.remote_config_file_invalid_url.id,
+                "username": self.user.username,
+                "filename": self.remote_config_file_invalid_url.file_name,
+            },
             {
                 "id": self.remote_config_file.id,
                 "username": self.user.username,
@@ -90,9 +154,12 @@ class ConfigFileApiTestCase(TestCase):
                 "filename": self.local_config_file.file_name,
             },
         ]
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data), 5)
         self.assertEqual(response.data[0]["filename"], expected_data[0]["filename"])
         self.assertEqual(response.data[1]["filename"], expected_data[1]["filename"])
+        self.assertEqual(response.data[2]["filename"], expected_data[2]["filename"])
+        self.assertEqual(response.data[3]["filename"], expected_data[3]["filename"])
+        self.assertEqual(response.data[4]["filename"], expected_data[4]["filename"])
 
     def test_get_config_file(self):
         """Test that an authenticated user can get a config file."""
@@ -129,20 +196,27 @@ class ConfigFileApiTestCase(TestCase):
         self.assertEqual(response.data["filename"], expected_data["filename"])
 
     @override_settings(DEFAULT_FILE_STORAGE="manager.utils.RemoteStorage")
-    def test_get_config_file_content_with_remote_storage(self):
+    def test_get_config_file_content_with_remote_storagex(self):
         """Test that an authenticated user can get a config file content."""
+
+        # Arrange:
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+
         mock_requests_get = mock.patch("requests.get")
         mock_requests_get_client = mock_requests_get.start()
         response_requests_get = requests.Response()
         response_requests_get.status_code = 200
+        response_requests_get.headers = {"content-type": "application/json"}
         response_requests_get.json = lambda: self.remote_config_file_content
         mock_requests_get_client.return_value = response_requests_get
 
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        # Act:
         response = self.client.get(
             reverse("configfile-content", args=[self.remote_config_file.id]),
             format="json",
         )
+
+        # Assert:
         self.assertEqual(response.status_code, 200)
         expected_data = {
             "id": self.remote_config_file.id,
@@ -152,6 +226,77 @@ class ConfigFileApiTestCase(TestCase):
         self.assertEqual(response.data["id"], expected_data["id"])
         self.assertEqual(response.data["content"], expected_data["content"])
         self.assertEqual(response.data["filename"], expected_data["filename"])
+
+        mock_requests_get.stop()
+
+    @override_settings(DEFAULT_FILE_STORAGE="manager.utils.RemoteStorage")
+    def test_get_config_file_content_with_remote_storage_error_invalid_url(self):
+        """Test that an authenticated user cannot get a config file content with an invalid url."""
+
+        # Arrange:
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+
+        # Act:
+        response = self.client.get(
+            reverse(
+                "configfile-content", args=[self.remote_config_file_invalid_url.id]
+            ),
+            format="json",
+        )
+
+        # Assert:
+        self.assertEqual(response.status_code, 400)
+
+    @override_settings(DEFAULT_FILE_STORAGE="manager.utils.RemoteStorage")
+    def test_get_config_file_content_with_remote_storage_error_file_not_found(self):
+        """Test that an authenticated user cannot get a config file content which cannot be found."""
+
+        # Arrange:
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+
+        mock_requests_get = mock.patch("requests.get")
+        mock_requests_get_client = mock_requests_get.start()
+        response_requests_get = requests.Response()
+        response_requests_get.status_code = 404
+        mock_requests_get_client.return_value = response_requests_get
+
+        # Act:
+        response = self.client.get(
+            reverse("configfile-content", args=[self.remote_config_file_not_found.id]),
+            format="json",
+        )
+
+        # Assert:
+        self.assertEqual(response.status_code, 400)
+
+        mock_requests_get.stop()
+
+    @override_settings(DEFAULT_FILE_STORAGE="manager.utils.RemoteStorage")
+    def test_get_config_file_content_with_remote_storage_error_file_type_not_allowed(
+        self,
+    ):
+        """Test that an authenticated user cannot get a config file content which cannot be found."""
+
+        # Arrange:
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+
+        mock_requests_get = mock.patch("requests.get")
+        mock_requests_get_client = mock_requests_get.start()
+        response_requests_get = requests.Response()
+        response_requests_get.status_code = 200
+        response_requests_get.headers = {"content-type": "text/csv"}
+        mock_requests_get_client.return_value = response_requests_get
+
+        # Act:
+        response = self.client.get(
+            reverse(
+                "configfile-content", args=[self.remote_config_file_type_not_allowed.id]
+            ),
+            format="json",
+        )
+
+        # Assert:
+        self.assertEqual(response.status_code, 400)
 
         mock_requests_get.stop()
 

--- a/manager/api/tests/test_configfile.py
+++ b/manager/api/tests/test_configfile.py
@@ -77,7 +77,7 @@ class ConfigFileApiTestCase(TestCase):
         self.remote_config_file_invalid_url = ConfigFile.objects.create(
             user=self.user,
             config_file=ConfigFileApiTestCase.get_config_file_sample(
-                "http://foo.bar/remote_filename.json",
+                "ftp://foo.bar/remote_filename.json",
                 self.remote_config_file_content,
             ),
             file_name="remote_filename_invalid_url",
@@ -196,7 +196,7 @@ class ConfigFileApiTestCase(TestCase):
         self.assertEqual(response.data["filename"], expected_data["filename"])
 
     @override_settings(DEFAULT_FILE_STORAGE="manager.utils.RemoteStorage")
-    def test_get_config_file_content_with_remote_storagex(self):
+    def test_get_config_file_content_with_remote_storage(self):
         """Test that an authenticated user can get a config file content."""
 
         # Arrange:

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -666,8 +666,12 @@ class ConfigFileViewSet(viewsets.ModelViewSet):
         except ConfigFile.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = ConfigFileContentSerializer(cf)
-        return Response(serializer.data)
+        try:
+            serializer_data = ConfigFileContentSerializer(cf).data
+        except Exception:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(serializer_data)
 
 
 class EmergencyContactViewSet(viewsets.ModelViewSet):
@@ -943,12 +947,11 @@ def lfa(request, *args, **kwargs):
                 )
 
         return Response(
-            {"ack": "All files uploaded correctly", "urls": uploaded_files_urls}, status=200
+            {"ack": "All files uploaded correctly", "urls": uploaded_files_urls},
+            status=200,
         )
-    
-    return Response(
-        {"ack": "Option not found"}, status=400
-    )
+
+    return Response({"ack": "Option not found"}, status=400)
 
 
 class CSCAuthorizationRequestViewSet(

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -26,11 +26,9 @@ class RemoteStorage(Storage):
     def _validate_LFA_url(self, name):
         """Validate the name of the file is a valid LFA url."""
         allowed_file_types = [t.split("/")[1] for t in RemoteStorage.ALLOWED_FILE_TYPES]
-        lfa_url_pattern = (
-            rf"https?:\/\/?.*lsst\.org\/.*\/LOVE\/.*({'|'.join(allowed_file_types)})$"
-        )
+        lfa_url_pattern = rf"https?:\/\/?.*\/.*({'|'.join(allowed_file_types)})$"
         if not re.match(lfa_url_pattern, name):
-            raise ValueError(f"Invalid LFA url: {name}")
+            raise ValueError(f"Invalid remote url: {name}")
 
     def _open(self, name, mode="rb"):
         """Return the remote file object."""


### PR DESCRIPTION
This PR is a hotfix for LOVE-manager version 5.11.1. On the latest release a bug was introduced which produced problems to read stored configuration files. The solution was to avoid file closing on the `open` method of the new `RemoteStorage` class.