### PR TITLE
Add changelog checker github action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,19 @@
+name: ChangelogUpdated
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - develop
+jobs:
+  build:
+    name: Check Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Changelog check
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.rst
+          checkNotification: Simple
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Version History
 v5.12.0
 --------
 
+* Add changelog checker github action `<https://github.com/lsst-ts/LOVE-manager/pull/193>`_
+* Fix file handling on RemoteStorage class `<https://github.com/lsst-ts/LOVE-manager/pull/192>`_
+* Hotfix/v5.11.0 `<https://github.com/lsst-ts/LOVE-manager/pull/191>`_
+* Bump cryptography from 39.0.1 to 41.0.0 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/187>`_
 * ScriptQueue Upgrade implementation `<https://github.com/lsst-ts/LOVE-manager/pull/186>`_
 
 v5.11.2


### PR DESCRIPTION
This PR adds configuration for the [Changelog checker](https://github.com/marketplace/actions/changelog-checker) github action.