### PR TITLE
Extend LOVE manager routing system for subpath app serving

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.14.0
+--------
+
+* Extend LOVE manager routing system for subpath app serving `<https://github.com/lsst-ts/LOVE-manager/pull/196>`_
+
 v5.13.0
 --------
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All these variables are initialized with default variables defined in :code:`.en
 - `LOVE_SITE`: defines the site name of the LOVE system. This value is used to identify the LOVE system in the LOVE-manager.
 - `REMOTE_STORAGE`: defines if remote storage is used. If this variable is defined, then the LOVE-manager will connect to the LFA to upload files. If not defined, then the LOVE-manager will store the files locally.
 - `COMMANDING_PERMISSION_TYPE`: defines the type of permission to use for commanding. Currently two options are available: `user` and `location`. If `user` is used, then requests from users with `api.command.execute_command` permission are allowed. If `location` is used, then only requests from the configured location of control will be allowed. If not defined, then `user` will be used.
-- `URL_SUBPATH`: defines the path where the LOVE-manager will be served. If not defined, then requests will be served from the root path `/`. Note: the application has its own routing system, so this variable must be thought as a prefix to the application's routes.
+- `URL_SUBPATH`: defines the path where the LOVE-manager will be served. If not defined, then requests will be served from the root path `/`. Note: the application has its own routing system, so this variable must be thought of as a prefix to the application's routes.
 
 # Local load for development
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All these variables are initialized with default variables defined in :code:`.en
 - `LOVE_SITE`: defines the site name of the LOVE system. This value is used to identify the LOVE system in the LOVE-manager.
 - `REMOTE_STORAGE`: defines if remote storage is used. If this variable is defined, then the LOVE-manager will connect to the LFA to upload files. If not defined, then the LOVE-manager will store the files locally.
 - `COMMANDING_PERMISSION_TYPE`: defines the type of permission to use for commanding. Currently two options are available: `user` and `location`. If `user` is used, then requests from users with `api.command.execute_command` permission are allowed. If `location` is used, then only requests from the configured location of control will be allowed. If not defined, then `user` will be used.
+- `URL_SUBPATH`: defines the path where the LOVE-manager will be served. If not defined, then requests will be served from the root path `/`. Note: the application has its own routing system, so this variable must be thought as a prefix to the application's routes.
 
 # Local load for development
 

--- a/manager/api/fixtures/initial_data_remote_tucson.json
+++ b/manager/api/fixtures/initial_data_remote_tucson.json
@@ -7,7 +7,7 @@
       "update_timestamp": "2020-12-29T14:21:31.040Z",
       "user": 1,
       "file_name": "default.json",
-      "config_file": "http://love.tu.lsst.org/media/configs/default.json"
+      "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/default.json"
     }
   },
   {

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -17,6 +17,10 @@ from django_auth_ldap.config import LDAPSearch
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
+# Define the URL subpath for this application when deployed:
+FORCE_SCRIPT_NAME = os.environ.get("URL_SUBPATH")
+
+# Define the type of storage to use for media files: remote or local
 DEFAULT_FILE_STORAGE = (
     "manager.utils.RemoteStorage"
     if os.environ.get("REMOTE_STORAGE")
@@ -181,7 +185,11 @@ TOKEN_EXPIRED_AFTER_DAYS = 30
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
-STATIC_URL = "/manager/static/"
+
+STATIC_URL = (
+    f"{FORCE_SCRIPT_NAME}/manager/static/" if FORCE_SCRIPT_NAME else "/manager/static/"
+)
+
 """URL to access Django static files (`string`)"""
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
@@ -197,7 +205,9 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static_files"),
 ]
 
-MEDIA_URL = "/media/"
+MEDIA_URL = (
+    f"{FORCE_SCRIPT_NAME}/manager/media/" if FORCE_SCRIPT_NAME else "/manager/media/"
+)
 """URL for media files access (`string`)"""
 
 if TESTING:

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -209,13 +209,8 @@ MEDIA_URL = (
     f"{FORCE_SCRIPT_NAME}/manager/media/" if FORCE_SCRIPT_NAME else "/manager/media/"
 )
 """URL for media files access (`string`)"""
-
-if TESTING:
-    MEDIA_BASE = os.path.join(BASE_DIR, "ui_framework", "tests")
-    MEDIA_ROOT = os.path.join(BASE_DIR, "ui_framework", "tests", "media")
-else:
-    MEDIA_BASE = BASE_DIR
-    MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MEDIA_BASE = BASE_DIR
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 # Channels
 ASGI_APPLICATION = "manager.routing.application"

--- a/manager/manager/urls.py
+++ b/manager/manager/urls.py
@@ -22,7 +22,6 @@ from django.views.generic import TemplateView
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from rest_framework import permissions
-from django.conf import settings
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -38,7 +37,8 @@ urlpatterns = [
     path("manager/admin/", admin.site.urls),
     path("manager/test/", TemplateView.as_view(template_name="test.html")),
     path(
-        "manager/login/", TemplateView.as_view(template_name="registration/login.html")
+        "manager/login/",
+        TemplateView.as_view(template_name="registration/login.html"),
     ),
     path("manager/api/", include("api.urls")),
     path("manager/ui_framework/", include("ui_framework.urls")),
@@ -57,5 +57,8 @@ urlpatterns = [
         schema_view.with_ui("redoc", cache_timeout=0),
         name="schema-redoc",
     ),
-    path("manager/schema_validation/", TemplateView.as_view(template_name="test.html")),
+    path(
+        "manager/schema_validation/",
+        TemplateView.as_view(template_name="test.html"),
+    ),
 ]

--- a/manager/runserver.sh
+++ b/manager/runserver.sh
@@ -36,4 +36,8 @@ fi
 python manage.py loaddata ui_framework/fixtures/initial_data_${love_site}.json
 
 echo -e "\nStarting server"
-daphne -b 0.0.0.0 -p 8000 manager.asgi:application
+if [ -z ${URL_SUBPATH} ]; then
+  daphne -b 0.0.0.0 -p 8000 manager.asgi:application
+else
+  daphne --root-path=${URL_SUBPATH} -b 0.0.0.0 -p 8000 manager.asgi:application
+fi

--- a/manager/subscription/routing.py
+++ b/manager/subscription/routing.py
@@ -2,10 +2,14 @@
 from django.conf.urls import url
 from subscription.auth import TokenAuthMiddleware
 from .consumers import SubscriptionConsumer
+from django.conf import settings
+
 
 websocket_urlpatterns = [
     url(
-        r"^manager(.*?)/ws/subscription/?$",
+        rf"^{settings.FORCE_SCRIPT_NAME[1:]}/manager(.*?)/ws/subscription/?$"
+        if settings.FORCE_SCRIPT_NAME
+        else r"^manager(.*?)/ws/subscription/?$",
         TokenAuthMiddleware(SubscriptionConsumer.as_asgi()),
     ),
 ]

--- a/manager/subscription/routing.py
+++ b/manager/subscription/routing.py
@@ -5,11 +5,11 @@ from .consumers import SubscriptionConsumer
 from django.conf import settings
 
 
+URL_PREFIX = settings.FORCE_SCRIPT_NAME[1:] + "/" if settings.FORCE_SCRIPT_NAME else ""
+
 websocket_urlpatterns = [
     url(
-        rf"^{settings.FORCE_SCRIPT_NAME[1:]}/manager(.*?)/ws/subscription/?$"
-        if settings.FORCE_SCRIPT_NAME
-        else r"^manager(.*?)/ws/subscription/?$",
+        rf"^{URL_PREFIX}manager(.*?)/ws/subscription/?$",
         TokenAuthMiddleware(SubscriptionConsumer.as_asgi()),
     ),
 ]

--- a/manager/ui_framework/tests/tests_view_thumbnail.py
+++ b/manager/ui_framework/tests/tests_view_thumbnail.py
@@ -12,7 +12,7 @@ from rest_framework.test import APIClient
 from ui_framework.models import View
 from unittest import mock
 from api.models import Token
-from manager import settings
+from django.conf import settings
 
 
 @override_settings(DEBUG=True)
@@ -139,7 +139,9 @@ class ViewThumbnailTestCase(TestCase):
 
         # - thumbnail url
         view = View.objects.get(name="view name")
-        self.assertEqual(view.thumbnail.url, "/media/thumbnails/view_1.png")
+        self.assertEqual(
+            view.thumbnail.url, f"{settings.MEDIA_URL}thumbnails/view_1.png"
+        )
 
         # - expected response data
         expected_response = {
@@ -152,7 +154,8 @@ class ViewThumbnailTestCase(TestCase):
         self.assertEqual(response.data, expected_response)
 
         # - stored file content
-        file_url = settings.MEDIA_BASE + view.thumbnail.url
+        thumbnail_url = view.thumbnail.url.replace("/manager/media/", "/")
+        file_url = settings.MEDIA_ROOT + thumbnail_url
         expected_url = mock_location + ".png"
         self.assertTrue(
             filecmp.cmp(file_url, expected_url),


### PR DESCRIPTION
This PR refactors the routing system of the LOVE-manager in order to allow serving the app from a sub path (e.g. /love).