### PR TITLE
Extend OLE views to allow multiple file upload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.14.2
 --------
 
+* Extend OLE views to allow multiple file upload `<https://github.com/lsst-ts/LOVE-manager/pull/203>`_
 * Add string representation for ScriptConfiguration model `<https://github.com/lsst-ts/LOVE-manager/pull/202>`_
 
 v5.14.1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   database:
     container_name: love-manager-database
-    image: postgres:12.0
+    image: postgres:15.0
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres

--- a/manager/api/tests/test_lfa.py
+++ b/manager/api/tests/test_lfa.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch, Mock
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import HttpRequest
+from django.test import TestCase, override_settings
+from django.utils.datastructures import MultiValueDict
+from api.views import lfa
+
+
+@override_settings(DEBUG=True)
+class LFATestCase(TestCase):
+    def setUp(self):
+        """Define the test suite setup."""
+        # Arrange
+        pass
+
+    @patch("requests.post")
+    def test_no_files_uploaded(self, mock_post):
+        request = HttpRequest()
+        request.FILES = MultiValueDict()
+        response = lfa(request, option="upload-file")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, {"ack": "No files to upload"})
+
+    @patch("requests.post")
+    def test_successful_file_upload(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": "http://example.com/uploaded-file"}
+        mock_post.return_value = mock_response
+
+        request = HttpRequest()
+        request.FILES["file[]"] = [SimpleUploadedFile("test.txt", b"file_content")]
+        response = lfa(request, option="upload-file")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "ack": "All files uploaded correctly",
+                "urls": ["http://example.com/uploaded-file"],
+            },
+        )
+
+    @patch("requests.post")
+    def test_successful_multiple_file_upload(self, mock_post):
+        # Create mock responses for the API
+        mock_response1 = Mock()
+        mock_response1.status_code = 200
+        mock_response1.json.return_value = {"url": "http://example.com/uploaded-file1"}
+
+        mock_response2 = Mock()
+        mock_response2.status_code = 200
+        mock_response2.json.return_value = {"url": "http://example.com/uploaded-file2"}
+
+        mock_post.side_effect = [
+            mock_response1,
+            mock_response2,
+        ]  # Mock responses for multiple file uploads
+
+        request = HttpRequest()
+        uploaded_file1 = SimpleUploadedFile("test1.txt", b"file_content_1")
+        uploaded_file2 = SimpleUploadedFile("test2.txt", b"file_content_2")
+        request.FILES = MultiValueDict({"file[]": [uploaded_file1, uploaded_file2]})
+
+        response = lfa(request, option="upload-file")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "ack": "All files uploaded correctly",
+                "urls": [
+                    "http://example.com/uploaded-file1",
+                    "http://example.com/uploaded-file2",
+                ],
+            },
+        )
+
+    @patch("requests.post")
+    def test_failed_file_upload(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_post.return_value = mock_response
+
+        request = HttpRequest()
+        request.FILES["file[]"] = [SimpleUploadedFile("test.txt", b"file_content")]
+        response = lfa(request, option="upload-file")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, {"ack": "Error when uploading files"})
+
+    def test_invalid_option(self):
+        request = HttpRequest()
+        request.FILES["file[]"] = [SimpleUploadedFile("test.txt", b"file_content")]
+        response = lfa(request, option="invalid-option")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, {"ack": "Option not found"})

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1334,7 +1334,7 @@ def jira(request):
 def jira_comment(request):
     """Connects to JIRA API to add a comment to a previously created ticket on a specific project.
     For more information on issuetypes refer to:
-    ttps://jira.lsstcorp.org/rest/api/latest/issuetype/?projectId=JIRA_PROJECT_ID
+    https://jira.lsstcorp.org/rest/api/latest/issuetype/?projectId=JIRA_PROJECT_ID
 
     Params
     ------
@@ -1457,7 +1457,6 @@ class ExposurelogViewSet(viewsets.ViewSet):
     The API is documented at https://summit-lsp.lsst.codes/exposurelog/docs.
     """
 
-    # serializer_class = ExposureLogSerializer
     permission_classes = (IsAuthenticated,)
     parser_classes = (MultiPartParser,)
 
@@ -1473,6 +1472,7 @@ class ExposurelogViewSet(viewsets.ViewSet):
         query_params_string = urllib.parse.urlencode(request.query_params)
         url = f"http://{os.environ.get('OLE_API_HOSTNAME')}/exposurelog/messages?{query_params_string}"
 
+        # Upload files to LFA
         lfa_urls = []
         files_to_upload = request.FILES.getlist("file[]")
         if len(files_to_upload) > 0:
@@ -1481,6 +1481,7 @@ class ExposurelogViewSet(viewsets.ViewSet):
                 return lfa_response
             lfa_urls = lfa_response.data.get("urls")
 
+        # Manage JIRA tickets
         jira_url = None
         if request.data.get("jira") == "true":
             request.data._mutable = True
@@ -1502,23 +1503,29 @@ class ExposurelogViewSet(viewsets.ViewSet):
                 )
             jira_url = jira_response.data.get("url")
 
+        # Make a copy of the request data for payload cleaning
+        # so it is json serializable
         json_data = request.data.copy()
+
         if "file[]" in json_data:
             del json_data["file[]"]
 
         if "tags" in json_data:
             json_data["tags"] = json_data["tags"].split(",")
 
+        # Add LFA and JIRA urls to the payload
         json_data["urls"] = [jira_url, *lfa_urls]
         json_data["urls"] = list(filter(None, json_data["urls"]))
 
+        # Add user agent and user id to the payload
         json_data["user_agent"] = "LOVE"
         json_data["user_id"] = f"{request.user}@{request.get_host()}"
 
+        # Send the request to the OLE API
+        # for each obs in the obs_id list
         for obs in request.data.get("obs_id").split(","):
             json_data["obs_id"] = obs
             response = requests.post(url, json=json_data)
-        # response = requests.post(url, json=json_data)
         return Response(response.json(), status=response.status_code)
 
     @swagger_auto_schema(responses={200: "Exposure log retrieved"})
@@ -1531,14 +1538,35 @@ class ExposurelogViewSet(viewsets.ViewSet):
     def update(self, request, pk=None, *args, **kwargs):
         url = f"http://{os.environ.get('OLE_API_HOSTNAME')}/exposurelog/messages/{pk}"
 
+        # Upload files to LFA
+        lfa_urls = []
+        files_to_upload = request.FILES.getlist("file[]")
+        if len(files_to_upload) > 0:
+            lfa_response = lfa(request, option="upload-file")
+            if lfa_response.status_code != 200:
+                return lfa_response
+            lfa_urls = lfa_response.data.get("urls")
+
+        # Make a copy of the request data for payload cleaning
+        # so it is json serializable
         json_data = request.data.copy()
+
+        if "file[]" in json_data:
+            del json_data["file[]"]
+
         if "tags" in json_data:
             json_data["tags"] = json_data["tags"].split(",")
         if "urls" in json_data:
             json_data["urls"] = json_data["urls"].split(",")
 
+        # Add LFA urls to the payload
+        json_data["urls"] = [
+            *(json_data["urls"] if "urls" in json_data else []),
+            *lfa_urls,
+        ]
+
+        # Send the request to the OLE API
         response = requests.patch(url, json=json_data)
-        # TODO: allow uploading a file on update
         return Response(response.json(), status=response.status_code)
 
     @swagger_auto_schema(responses={200: "Exposure log deleted"})
@@ -1565,7 +1593,6 @@ class NarrativelogViewSet(viewsets.ViewSet):
     The API is documented at https://summit-lsp.lsst.codes/narrativelog/docs.
     """
 
-    # serializer_class = NarrativeLogSerializer
     permission_classes = (IsAuthenticated,)
     parser_classes = (MultiPartParser,)
 
@@ -1581,6 +1608,7 @@ class NarrativelogViewSet(viewsets.ViewSet):
         query_params_string = urllib.parse.urlencode(request.query_params)
         url = f"http://{os.environ.get('OLE_API_HOSTNAME')}/narrativelog/messages?{query_params_string}"
 
+        # Upload files to LFA
         lfa_urls = []
         files_to_upload = request.FILES.getlist("file[]")
         if len(files_to_upload) > 0:
@@ -1589,6 +1617,7 @@ class NarrativelogViewSet(viewsets.ViewSet):
                 return lfa_response
             lfa_urls = lfa_response.data.get("urls")
 
+        # Manage JIRA tickets
         jira_url = None
         if request.data.get("jira") == "true":
             request.data._mutable = True
@@ -1610,7 +1639,10 @@ class NarrativelogViewSet(viewsets.ViewSet):
                 )
             jira_url = jira_response.data.get("url")
 
+        # Make a copy of the request data for payload cleaning
+        # so it is json serializable
         json_data = request.data.copy()
+
         if "file[]" in json_data:
             del json_data["file[]"]
 
@@ -1623,9 +1655,11 @@ class NarrativelogViewSet(viewsets.ViewSet):
         if "cscs" in json_data:
             json_data["cscs"] = json_data["cscs"].split(",")
 
+        # Add LFA and JIRA urls to the payload
         json_data["urls"] = [jira_url, *lfa_urls]
         json_data["urls"] = list(filter(None, json_data["urls"]))
 
+        # Add user agent and user id to the payload
         json_data["user_agent"] = "LOVE"
         json_data["user_id"] = f"{request.user}@{request.get_host()}"
 
@@ -1642,7 +1676,22 @@ class NarrativelogViewSet(viewsets.ViewSet):
     def update(self, request, pk=None, *args, **kwargs):
         url = f"http://{os.environ.get('OLE_API_HOSTNAME')}/narrativelog/messages/{pk}"
 
+        # Upload files to LFA
+        lfa_urls = []
+        files_to_upload = request.FILES.getlist("file[]")
+        if len(files_to_upload) > 0:
+            lfa_response = lfa(request, option="upload-file")
+            if lfa_response.status_code != 200:
+                return lfa_response
+            lfa_urls = lfa_response.data.get("urls")
+
+        # Make a copy of the request data for payload cleaning
+        # so it is json serializable
         json_data = request.data.copy()
+
+        if "file[]" in json_data:
+            del json_data["file[]"]
+
         if "tags" in json_data:
             json_data["tags"] = json_data["tags"].split(",")
         if "systems" in json_data:
@@ -1654,8 +1703,14 @@ class NarrativelogViewSet(viewsets.ViewSet):
         if "urls" in json_data:
             json_data["urls"] = json_data["urls"].split(",")
 
+        # Add LFA urls to the payload
+        json_data["urls"] = [
+            *(json_data["urls"] if "urls" in json_data else []),
+            *lfa_urls,
+        ]
+
+        # Send the request to the OLE API
         response = requests.patch(url, json=json_data)
-        # TODO: allow uploading a file on update
         return Response(response.json(), status=response.status_code)
 
     @swagger_auto_schema(responses={200: "Narrative log deleted"})


### PR DESCRIPTION
This PR extends the OLE views in order to allow multiple file upload on the `create` and `update` methods of the `NarrativeLogViewSet` and `ExposureLogViewSet`.