### PR TITLE
Hotfix/v5.14.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.14.5
 -------
 
+* Hotfix/v5.14.5 `<https://github.com/lsst-ts/LOVE-manager/pull/207>`_
 * LOVE License `<https://github.com/lsst-ts/LOVE-manager/pull/206>`_
 
 v5.14.4

--- a/manager/runserver-dev.sh
+++ b/manager/runserver-dev.sh
@@ -1,25 +1,4 @@
-# !/bin/bash
-
-# This file is part of LOVE-manager.
-#
-# Copyright (c) 2023 Inria Chile.
-#
-# Developed by Inria Chile.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or at
-# your option any later version.
-#
-# This program is distributed in the hope that it will be useful,but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-# for more details.
-#
-# You should have received a copy of the GNU General Public License along with
-# this program. If not, see <http://www.gnu.org/licenses/>.
-
-
+#!/bin/bash
 echo -e "\nMaking migrations"
 while ! python manage.py makemigrations
 do

--- a/manager/runserver.sh
+++ b/manager/runserver.sh
@@ -1,25 +1,5 @@
 # !/bin/bash
 
-# This file is part of LOVE-manager.
-#
-# Copyright (c) 2023 Inria Chile.
-#
-# Developed by Inria Chile.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or at
-# your option any later version.
-#
-# This program is distributed in the hope that it will be useful,but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-# for more details.
-#
-# You should have received a copy of the GNU General Public License along with
-# this program. If not, see <http://www.gnu.org/licenses/>.
-
-
 echo -e "\nMaking migrations"
 while ! python manage.py makemigrations
 do

--- a/manager/runtasks.sh
+++ b/manager/runtasks.sh
@@ -1,24 +1,4 @@
-# !/bin/bash
-
-# This file is part of LOVE-manager.
-#
-# Copyright (c) 2023 Inria Chile.
-#
-# Developed by Inria Chile.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or at
-# your option any later version.
-#
-# This program is distributed in the hope that it will be useful,but
-# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-# for more details.
-#
-# You should have received a copy of the GNU General Public License along with
-# this program. If not, see <http://www.gnu.org/licenses/>.
-
+#!/bin/bash
 
 echo -e "\nStarting process for background tasks"
 python manage.py process_tasks


### PR DESCRIPTION
This PR removed comments on .sh files. These comments indicated issues with the manager scripts, preventing them from executing correctly and, as a result, not launching the local environment properly (or in live-csc mode).