### PR TITLE
Reduce miliseconds part of time of incident timestamps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.14.8
 -------
 
+* Reduce miliseconds part of time of incident timestamps `<https://github.com/lsst-ts/LOVE-manager/pull/217>`_
 * Possibly malformed YAML in script dialog causes crash loop on subsequent use `<https://github.com/lsst-ts/LOVE-manager/pull/216>`_
 
 v5.14.7

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -19,15 +19,16 @@
 
 
 import random
-import requests
-
-from api.views import jira_ticket, jira_comment
-from django.test import TestCase, override_settings
 from unittest.mock import patch
+
+import requests
+from api.views import jira_comment, jira_ticket
+from django.test import TestCase, override_settings
+
 from manager.utils import (
     OLE_JIRA_OBS_COMPONENTS_FIELDS,
-    OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS,
     OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS,
+    OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS,
 )
 
 
@@ -73,8 +74,8 @@ class JiraTestCase(TestCase):
             "primary_hardware_components": list(
                 OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS.keys()
             )[0],
-            "date_begin": "202200703-19:58:13",
-            "date_end": "20220704-19:25:13",
+            "date_begin": "2022-07-03T19:58:13.00000",
+            "date_end": "2022-07-04T19:25:13.00000",
             "time_lost": 10,
             "level": 0,
         }


### PR DESCRIPTION
This PR parses the `date_begin` and `date_end` parameters of the narrative log requests to remove the miliseconds part of the datetime string.