### PR TITLE
Remove JIRA fields ids mapping

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.14.9
 -------
 
+* Remove JIRA fields ids mapping `<https://github.com/lsst-ts/LOVE-manager/pull/221>`_
 * Bump urllib3 from 1.26.17 to 1.26.18 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/218>`_
 
 v5.14.8

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -18,6 +18,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
 
+import math
 import random
 from unittest.mock import patch
 
@@ -25,11 +26,41 @@ import requests
 from api.views import jira_comment, jira_ticket
 from django.test import TestCase, override_settings
 
-from manager.utils import (
-    OLE_JIRA_OBS_COMPONENTS_FIELDS,
-    OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS,
-    OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS,
-)
+OLE_JIRA_OBS_COMPONENTS_FIELDS = [
+    "AuxTel",
+    "Calibrations",
+    "Environmental Monitoring Systems",
+    "Facilities",
+    "IT Infrastricture",
+    "MainTel",
+    "Observer Remark",
+    "Other",
+    "Unknown",
+]
+
+OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS = [
+    "None",
+    "CSC level",
+    "Component Level (EUI)",
+    "Visualization",
+    "Analysis",
+    "Other",
+    "Camera Control Software",
+]
+
+OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS = [
+    "None",
+    "Mount",
+    "Rotator",
+    "Hexapod",
+    "M2",
+    "Science Cameras",
+    "M1M3",
+    "Dome",
+    "Utilities",
+    "Calibration",
+    "Other",
+]
 
 
 @override_settings(DEBUG=True)
@@ -67,13 +98,23 @@ class JiraTestCase(TestCase):
         }
 
         request_narrative = {
-            "components": ",".join(list(OLE_JIRA_OBS_COMPONENTS_FIELDS.keys())[:2]),
-            "primary_software_components": list(
-                OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS.keys()
-            )[0],
-            "primary_hardware_components": list(
-                OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS.keys()
-            )[0],
+            "components": ",".join(
+                OLE_JIRA_OBS_COMPONENTS_FIELDS[
+                    : math.ceil(random.random() * len(OLE_JIRA_OBS_COMPONENTS_FIELDS))
+                ]
+            ),
+            "primary_software_components": OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS[
+                math.ceil(
+                    random.random()
+                    * len(OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS)
+                )
+            ],
+            "primary_hardware_components": OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS[
+                math.ceil(
+                    random.random()
+                    * len(OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS)
+                )
+            ],
             "date_begin": "2022-07-03T19:58:13.00000",
             "date_end": "2022-07-04T19:25:13.00000",
             "time_lost": 10,

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -99,22 +99,39 @@ class JiraTestCase(TestCase):
 
         request_narrative = {
             "components": ",".join(
-                OLE_JIRA_OBS_COMPONENTS_FIELDS[
-                    : math.ceil(random.random() * len(OLE_JIRA_OBS_COMPONENTS_FIELDS))
+                list(
+                    OLE_JIRA_OBS_COMPONENTS_FIELDS[
+                        : math.ceil(
+                            random.random() * (len(OLE_JIRA_OBS_COMPONENTS_FIELDS) - 1)
+                        )
+                    ]
+                )
+            ),
+            "components_ids": ",".join(
+                [str(n) for n in range(1, math.ceil(random.random() * 100))]
+            ),
+            "primary_software_components": ",".join(
+                OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS[
+                    math.ceil(
+                        random.random()
+                        * (len(OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS) - 1)
+                    )
                 ]
             ),
-            "primary_software_components": OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS[
-                math.ceil(
-                    random.random()
-                    * len(OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS)
-                )
-            ],
-            "primary_hardware_components": OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS[
-                math.ceil(
-                    random.random()
-                    * len(OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS)
-                )
-            ],
+            "primary_software_components_ids": ",".join(
+                [str(math.ceil(random.random() * 100))]
+            ),
+            "primary_hardware_components": ",".join(
+                OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS[
+                    math.ceil(
+                        random.random()
+                        * (len(OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS) - 1)
+                    )
+                ]
+            ),
+            "primary_hardware_components_ids": ",".join(
+                [str(math.ceil(random.random() * 100))]
+            ),
             "date_begin": "2022-07-03T19:58:13.00000",
             "date_end": "2022-07-04T19:25:13.00000",
             "time_lost": 10,

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -36,43 +36,6 @@ from rest_framework.response import Response
 JSON_RESPONSE_LOCAL_STORAGE_NOT_ALLOWED = {"error": "Local storage not allowed."}
 JSON_RESPONSE_ERROR_NOT_VALID_JSON = {"error": "Not a valid JSON response."}
 
-# Mappings
-OLE_JIRA_OBS_COMPONENTS_FIELDS = {
-    "AuxTel": 20710,
-    "Calibrations": 20714,
-    "Environmental Monitoring Systems": 20711,
-    "Facilities": 20712,
-    "IT Infrastricture": 20718,
-    "MainTel": 20709,
-    "Observer Remark": 20717,
-    "Other": 20713,
-    "Unknown": 19507,
-}
-
-OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS = {
-    "None": -1,
-    "CSC level": 16810,
-    "Component Level (EUI)": 16811,
-    "Visualization": 16812,
-    "Analysis": 16813,
-    "Other": 16814,
-    "Camera Control Software": 16815,
-}
-
-OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS = {
-    "None": -1,
-    "Mount": 16816,
-    "Rotator": 16817,
-    "Hexapod": 16818,
-    "M2": 16819,
-    "Science Cameras": 16820,
-    "M1M3": 16821,
-    "Dome": 16822,
-    "Utilities": 16825,
-    "Calibration": 16826,
-    "Other": 16827,
-}
-
 
 class LocationPermission(BasePermission):
     """Permission class to check if the user is in the location whitelist."""
@@ -432,24 +395,21 @@ def jira_ticket(request_data):
         return Response({"ack": "Error reading request type"}, status=400)
 
     tags_data = request_data.get("tags").split(",") if request_data.get("tags") else []
-    components_data = (
-        request_data.get("components").split(",")
-        if request_data.get("components")
+    components_ids = (
+        request_data.get("components_ids").split(",")
+        if request_data.get("components_ids")
         else []
     )
-    components_ids = [OLE_JIRA_OBS_COMPONENTS_FIELDS[c] for c in components_data]
-    primary_software_component_data = request_data.get(
-        "primary_software_components", "None"
+    primary_software_components_ids = (
+        request_data.get("primary_software_components_ids").split(",")
+        if request_data.get("primary_software_components_ids")
+        else []
     )
-    primary_software_component_id = OLE_JIRA_OBS_PRIMARY_SOFTWARE_COMPONENT_FIELDS[
-        primary_software_component_data
-    ]
-    primary_hardware_component_data = request_data.get(
-        "primary_hardware_components", "None"
+    primary_hardware_components_ids = (
+        request_data.get("primary_hardware_components_ids").split(",")
+        if request_data.get("primary_hardware_components_ids")
+        else []
     )
-    primary_hardware_component_id = OLE_JIRA_OBS_PRIMARY_HARDWARE_COMPONENT_FIELDS[
-        primary_hardware_component_data
-    ]
 
     try:
         jira_payload = {
@@ -465,8 +425,8 @@ def jira_ticket(request_data):
                 if int(request_data.get("level", 0)) >= 100
                 else "off",
                 "customfield_16702": float(request_data.get("time_lost", 0)),
-                "customfield_17204": {"id": str(primary_software_component_id)},
-                "customfield_17205": {"id": str(primary_hardware_component_id)},
+                "customfield_17204": {"id": str(primary_software_components_ids[0])},
+                "customfield_17205": {"id": str(primary_hardware_components_ids[0])},
                 "issuetype": {"id": 12302},
             },
             "update": {

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -395,6 +395,7 @@ def jira_ticket(request_data):
         return Response({"ack": "Error reading request type"}, status=400)
 
     tags_data = request_data.get("tags").split(",") if request_data.get("tags") else []
+
     components_ids = (
         request_data.get("components_ids").split(",")
         if request_data.get("components_ids")
@@ -403,17 +404,18 @@ def jira_ticket(request_data):
     primary_software_components_ids = (
         request_data.get("primary_software_components_ids").split(",")
         if request_data.get("primary_software_components_ids")
-        else []
+        else None
     )
     primary_hardware_components_ids = (
         request_data.get("primary_hardware_components_ids").split(",")
         if request_data.get("primary_hardware_components_ids")
-        else []
+        else None
     )
 
     try:
         jira_payload = {
             "fields": {
+                "issuetype": {"id": 12302},
                 "project": {"id": os.environ.get("JIRA_PROJECT_ID")},
                 "labels": [
                     "LOVE",
@@ -425,9 +427,17 @@ def jira_ticket(request_data):
                 if int(request_data.get("level", 0)) >= 100
                 else "off",
                 "customfield_16702": float(request_data.get("time_lost", 0)),
-                "customfield_17204": {"id": str(primary_software_components_ids[0])},
-                "customfield_17205": {"id": str(primary_hardware_components_ids[0])},
-                "issuetype": {"id": 12302},
+                # Default values of the following fields are set to -1
+                "customfield_17204": {
+                    "id": str(primary_software_components_ids[0])
+                    if primary_software_components_ids
+                    else "-1"
+                },
+                "customfield_17205": {
+                    "id": str(primary_hardware_components_ids[0])
+                    if primary_hardware_components_ids
+                    else "-1"
+                },
             },
             "update": {
                 "components": [{"set": [{"id": str(id)} for id in components_ids]}]


### PR DESCRIPTION
This PR removes the ids mapping of the JIRA fields in order to keep that in one single place, the LOVE-frontend (check [PR#547](https://github.com/lsst-ts/LOVE-frontend/pull/547)).