### PR TITLE
Update WeatherStation component salindex on UI Framework fixtures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.14.10
+--------
+
+* Update WeatherStation component salindex on UI Framework fixtures `<https://github.com/lsst-ts/LOVE-manager/pull/223>`_
+
 v5.14.9
 -------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -172,9 +172,9 @@
               "link": "",
               "title": "Weather station component",
               "margin": true,
-              "salindex": 1,
+              "salindex": 301,
               "titleBar": true,
-              "hasRawMode": false
+              "hasRawMode": true
             },
             "content": "WeatherStation",
             "properties": {

--- a/manager/ui_framework/fixtures/initial_data_inria.json
+++ b/manager/ui_framework/fixtures/initial_data_inria.json
@@ -172,9 +172,9 @@
               "link": "",
               "title": "Weather station component",
               "margin": true,
-              "salindex": 1,
+              "salindex": 301,
               "titleBar": true,
-              "hasRawMode": false
+              "hasRawMode": true
             },
             "content": "WeatherStation",
             "properties": {

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -172,7 +172,7 @@
               "link": "",
               "title": "Weather station component",
               "margin": true,
-              "salindex": 1,
+              "salindex": 301,
               "titleBar": true,
               "hasRawMode": false
             },
@@ -2147,9 +2147,9 @@
               "title": "Weather station component",
               "margin": true,
               "controls": true,
-              "salindex": 1,
+              "salindex": 301,
               "titleBar": true,
-              "hasRawMode": false
+              "hasRawMode": true
             },
             "content": "WeatherStation",
             "properties": {

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -172,9 +172,9 @@
               "link": "",
               "title": "Weather station component",
               "margin": true,
-              "salindex": 1,
+              "salindex": 301,
               "titleBar": true,
-              "hasRawMode": false
+              "hasRawMode": true
             },
             "content": "WeatherStation",
             "properties": {


### PR DESCRIPTION
This PR adjusts fixture fields to adjust the `WeatherStation` salindex so the change is persisted.