### PR TITLE
Manager performance improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Version History
 ===============
 
-v5.14.11
---------
+v5.15.0
+-------
 
+* Manager performance improvements `<https://github.com/lsst-ts/LOVE-manager/pull/224>`_
 * Bump twisted from 22.10.0 to 23.10.0 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/222>`_
 
 v5.14.10

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -31,6 +31,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+
 import ldap
 from django_auth_ldap.config import LDAPSearch
 
@@ -59,7 +60,8 @@ get from the `TESTING` environment variable (`string`)"""
 SECRET_KEY = os.getenv(
     "SECRET_KEY", "tbder3gzppu)kl%(u3awhhg^^zu#j&!ceh@$n&v0d38sjx43s8"
 )
-"""Secret Key for Django, read from the `SECRET_KEY` environment variable (`string`)"""
+"""Secret Key for Django, read from the `SECRET_KEY`
+environment variable (`string`)"""
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if os.environ.get("NO_DEBUG"):
@@ -255,6 +257,11 @@ if REDIS_HOST and not TESTING:
                 ],
                 "expiry": REDIS_CONFIG_EXPIRY,
                 "capacity": REDIS_CONFIG_CAPACITY,
+                # Set group_expiry to 1 year to avoid group messages being
+                # dropped when the group is not used frequently.
+                # TODO: Solve this particular issue in a better way.
+                # See: DM-41728
+                "group_expiry": 31536000,
             },
         },
     }
@@ -274,7 +281,8 @@ AUTHENTICATION_BACKENDS = [
 AUTH_LDAP_1_SERVER_URI = os.environ.get("AUTH_LDAP_1_SERVER_URI")
 AUTH_LDAP_2_SERVER_URI = os.environ.get("AUTH_LDAP_2_SERVER_URI")
 AUTH_LDAP_3_SERVER_URI = os.environ.get("AUTH_LDAP_3_SERVER_URI")
-"""URL for the LDAP server. Read from `AUTH_LDAP_SERVER_URI` environment variable (`bool`)"""
+"""URL for the LDAP server. Read from `AUTH_LDAP_SERVER_URI`
+environment variable (`bool`)"""
 
 # Only use LDAP activation backend if there is an AUTH_LDAP_SERVER_URI
 AUTH_LDAP_BIND_DN = "uid=svc_love,cn=users,cn=accounts,dc=lsst,dc=cloud"
@@ -323,7 +331,8 @@ HEARTBEAT_QUERY_COMMANDER = (
 )
 
 # LOVE-PRODUCER-CONFIGURATION
-"""Defines wether or not ussing the legacy LOVE-producer version, i.e. not the LOVE CSC Producer"""
+"""Defines wether or not ussing the legacy LOVE-producer version,
+i.e. not the LOVE CSC Producer"""
 LOVE_PRODUCER_LEGACY = os.environ.get("LOVE_PRODUCER_LEGACY", False)
 
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -93,8 +93,10 @@ class RemoteStorage(Storage):
     ]
 
     def __init__(self, location=None):
-        self.location = f"http://{os.environ.get('COMMANDER_HOSTNAME')}\
-        :{os.environ.get('COMMANDER_PORT')}/lfa"
+        self.location = (
+            f"http://{os.environ.get('COMMANDER_HOSTNAME')}"
+            f":{os.environ.get('COMMANDER_PORT')}/lfa"
+        )
 
     def _validate_LFA_url(self, name):
         """Validate the name of the file is a valid LFA url."""

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -18,7 +18,6 @@ constantly==15.1.0
 coreapi==2.3.3
 coreschema==0.0.4
 cryptography==41.0.4
-daphne==3.0.1
 Django==3.1.14
 django-auth-ldap==4.1.0
 django-cors-headers==3.2.1
@@ -86,6 +85,7 @@ Twisted==23.10.0
 txaio==20.1.1
 uritemplate==3.0.1
 urllib3==1.26.18
+uvicorn[standard]==0.24.0.post1
 wcwidth==0.1.8
 zipp==3.1.0
 zope.interface==4.7.2

--- a/manager/runserver.sh
+++ b/manager/runserver.sh
@@ -38,7 +38,7 @@ python manage.py loaddata ui_framework/fixtures/initial_data_${love_site}.json
 
 echo -e "\nStarting server"
 if [ -z ${URL_SUBPATH} ]; then
-  daphne -b 0.0.0.0 -p 8000 manager.asgi:application
+  python -m uvicorn --host 0.0.0.0 --port 8000 manager.asgi:application
 else
-  daphne --root-path=${URL_SUBPATH} -b 0.0.0.0 -p 8000 manager.asgi:application
+  python -m uvicorn --root-path=${URL_SUBPATH} --host 0.0.0.0 --port 8000 manager.asgi:application
 fi


### PR DESCRIPTION
This PR changes a couple configurations on the LOVE-manager service:

- Replace `daphne` per `uvicorn` a lightweight fast python ASGI server as it reduces memory use considerably.
- Set `group_expiry` channels_redis configuration to big limit so no initial_state channels are being erased for non activity. See [DM-41728](https://jira.lsstcorp.org/browse/DM-41728).

Also the remote storage feature was fixed.