### PR TITLE
Increase users uploads max file size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.15.1
 -------
 
+* Increase users uploads max file size `<https://github.com/lsst-ts/LOVE-manager/pull/227>`_
 * Add missing base fixtures `<https://github.com/lsst-ts/LOVE-manager/pull/225>`_
 
 v5.15.0

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -38,6 +38,9 @@ from django_auth_ldap.config import LDAPSearch
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
+# Define the max file size for user uploads
+FILE_UPLOAD_MAX_MEMORY_SIZE = 5242880
+
 # Define the URL subpath for this application when deployed:
 FORCE_SCRIPT_NAME = os.environ.get("URL_SUBPATH")
 


### PR DESCRIPTION
This PR sets the `FILE_UPLOAD_MAX_MEMORY_SIZE` setting to 5242880, i.e 5MB. This users will be allowed to upload files up to that limit.