### PR TITLE
Extend OLE update methods to allow JIRA ticket attachment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.17.1
+-------
+
+* Extend OLE update methods to allow JIRA ticket attachment `<https://github.com/lsst-ts/LOVE-manager/pull/235>`_
+
 v5.17.0
 -------
 

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -18,8 +18,10 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-import requests
 from unittest.mock import patch
+
+import requests
+import rest_framework.response
 from api.models import Token
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
@@ -58,31 +60,63 @@ class OLETestCase(TestCase):
         }
 
         payload_exposure = {
+            "request_type": "exposure",
             "obs_id": "AT_O_20220208_000140",
             "instrument": "LATISS",
             "exposure_flag": "none",
         }
 
         payload_narrative = {
-            "systems": "MainTel",
-            "subsystems": "Camera",
-            "cscs": "M1M3",
+            "request_type": "narrative",
+            "components": "MainTel",
+            "primary_software_components": "None",
+            "primary_hardware_components": "None",
             "date_begin": "202200703-19:58:13",
             "date_end": "20220704-19:25:13",
             "time_lost": 10,
             "level": 0,
         }
 
+        payload_jira_new = {
+            "jira": "true",
+            "jira_new": "true",
+            "jira_issue_title": "Issue title",
+        }
+
+        payload_jira_comment = {
+            "jira": "true",
+            "jira_new": "false",
+            "jira_issue_id": "LOVE-1234",
+        }
+
         self.payload_full_exposure = {
             **payload_shared,
             **payload_exposure,
-            "request_type": "exposure",
         }
 
         self.payload_full_narrative = {
             **payload_shared,
             **payload_narrative,
-            "request_type": "narrative",
+        }
+
+        self.payload_full_exposure_with_jira_new = {
+            **self.payload_full_exposure,
+            **payload_jira_new,
+        }
+
+        self.payload_full_exposure_with_jira_comment = {
+            **self.payload_full_exposure,
+            **payload_jira_comment,
+        }
+
+        self.payload_full_narrative_with_jira_new = {
+            **self.payload_full_narrative,
+            **payload_jira_new,
+        }
+
+        self.payload_full_narrative_with_jira_comment = {
+            **self.payload_full_narrative,
+            **payload_jira_comment,
         }
 
     def test_exposurelog_list(self):
@@ -143,6 +177,96 @@ class OLETestCase(TestCase):
         response = self.client.put(url, self.payload_full_exposure)
         self.assertEqual(response.status_code, 200)
 
+    def test_exposurelog_create_with_jira(self):
+        """Test exposurelog create with jira."""
+        # Arrange:
+        mock_jira_ticket_patcher = patch("manager.utils.jira_ticket")
+        mock_jira_ticket_client = mock_jira_ticket_patcher.start()
+        response_jira_new = rest_framework.response.Response()
+        response_jira_new.status_code = 200
+        response_jira_new.data = {
+            "ack": "Jira ticket created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_ticket_client.return_value = response_jira_new
+
+        mock_jira_comment_patcher = patch("manager.utils.jira_comment")
+        mock_jira_comment_client = mock_jira_comment_patcher.start()
+        response_jira_comment = rest_framework.response.Response()
+        response_jira_comment.status_code = 200
+        response_jira_comment.data = {
+            "ack": "Jira comment created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_comment_client.return_value = response_jira_comment
+
+        mock_ole_patcher = patch("requests.post")
+        mock_ole_client = mock_ole_patcher.start()
+        response_ole = requests.Response()
+        response_ole.status_code = 201
+        response_ole.json = lambda: {}
+        mock_ole_client.return_value = response_ole
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+
+        # Act:
+        # New jira ticket
+        url = reverse("ExposureLogs-list")
+        response = self.client.post(url, self.payload_full_exposure_with_jira_new)
+        self.assertEqual(response.status_code, 201)
+
+        # Existent jira ticket
+        url = reverse("ExposureLogs-list")
+        response = self.client.post(url, self.payload_full_exposure_with_jira_comment)
+        self.assertEqual(response.status_code, 201)
+
+    def test_exposurelog_update_with_jira(self):
+        """Test exposurelog update with jira."""
+        # Arrange:
+        mock_jira_ticket_patcher = patch("manager.utils.jira_ticket")
+        mock_jira_ticket_client = mock_jira_ticket_patcher.start()
+        response_jira_new = rest_framework.response.Response()
+        response_jira_new.status_code = 200
+        response_jira_new.data = {
+            "ack": "Jira ticket created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_ticket_client.return_value = response_jira_new
+
+        mock_jira_comment_patcher = patch("manager.utils.jira_comment")
+        mock_jira_comment_client = mock_jira_comment_patcher.start()
+        response_jira_comment = rest_framework.response.Response()
+        response_jira_comment.status_code = 200
+        response_jira_comment.data = {
+            "ack": "Jira comment created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_comment_client.return_value = response_jira_comment
+
+        mock_ole_patcher = patch("requests.patch")
+        mock_ole_client = mock_ole_patcher.start()
+        response_ole = requests.Response()
+        response_ole.status_code = 200
+        response_ole.json = lambda: {}
+        mock_ole_client.return_value = response_ole
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+
+        # Act:
+        # New jira ticket
+        url = reverse("ExposureLogs-detail", args=[1])
+        response = self.client.put(url, self.payload_full_exposure_with_jira_new)
+        self.assertEqual(response.status_code, 200)
+
+        # Existent jira ticket
+        url = reverse("ExposureLogs-detail", args=[1])
+        response = self.client.put(url, self.payload_full_exposure_with_jira_comment)
+        self.assertEqual(response.status_code, 200)
+
     def test_narrativelog_list(self):
         """Test narrativelog list."""
         # Arrange:
@@ -199,4 +323,94 @@ class OLETestCase(TestCase):
         # Act:
         url = reverse("NarrativeLogs-detail", args=[1])
         response = self.client.put(url, self.payload_full_narrative)
+        self.assertEqual(response.status_code, 200)
+
+    def test_narrative_log_create_with_jira(self):
+        """Test narrativelog create with jira."""
+        # Arrange:
+        mock_jira_ticket_patcher = patch("manager.utils.jira_ticket")
+        mock_jira_ticket_client = mock_jira_ticket_patcher.start()
+        response_jira_new = rest_framework.response.Response()
+        response_jira_new.status_code = 200
+        response_jira_new.data = {
+            "ack": "Jira ticket created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_ticket_client.return_value = response_jira_new
+
+        mock_jira_comment_patcher = patch("manager.utils.jira_comment")
+        mock_jira_comment_client = mock_jira_comment_patcher.start()
+        response_jira_comment = rest_framework.response.Response()
+        response_jira_comment.status_code = 200
+        response_jira_comment.data = {
+            "ack": "Jira comment created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_comment_client.return_value = response_jira_comment
+
+        mock_ole_patcher = patch("requests.post")
+        mock_ole_client = mock_ole_patcher.start()
+        response_ole = requests.Response()
+        response_ole.status_code = 201
+        response_ole.json = lambda: {}
+        mock_ole_client.return_value = response_ole
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+
+        # Act:
+        # New jira ticket
+        url = reverse("NarrativeLogs-list")
+        response = self.client.post(url, self.payload_full_narrative_with_jira_new)
+        self.assertEqual(response.status_code, 201)
+
+        # Existent jira ticket
+        url = reverse("NarrativeLogs-list")
+        response = self.client.post(url, self.payload_full_narrative_with_jira_comment)
+        self.assertEqual(response.status_code, 201)
+
+    def test_narrative_log_update_with_jira(self):
+        """Test narrativelog update with jira."""
+        # Arrange:
+        mock_jira_ticket_patcher = patch("manager.utils.jira_ticket")
+        mock_jira_ticket_client = mock_jira_ticket_patcher.start()
+        response_jira_new = rest_framework.response.Response()
+        response_jira_new.status_code = 200
+        response_jira_new.data = {
+            "ack": "Jira ticket created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_ticket_client.return_value = response_jira_new
+
+        mock_jira_comment_patcher = patch("manager.utils.jira_comment")
+        mock_jira_comment_client = mock_jira_comment_patcher.start()
+        response_jira_comment = rest_framework.response.Response()
+        response_jira_comment.status_code = 200
+        response_jira_comment.data = {
+            "ack": "Jira comment created",
+            "url": "https://jira.lsstcorp.org/browse/LOVE-1234",
+        }
+        mock_jira_comment_client.return_value = response_jira_comment
+
+        mock_ole_patcher = patch("requests.patch")
+        mock_ole_client = mock_ole_patcher.start()
+        response_ole = requests.Response()
+        response_ole.status_code = 200
+        response_ole.json = lambda: {}
+        mock_ole_client.return_value = response_ole
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+
+        # Act:
+        # New jira ticket
+        url = reverse("NarrativeLogs-detail", args=[1])
+        response = self.client.put(url, self.payload_full_narrative_with_jira_new)
+        self.assertEqual(response.status_code, 200)
+
+        # Existent jira ticket
+        url = reverse("NarrativeLogs-detail", args=[1])
+        response = self.client.put(url, self.payload_full_narrative_with_jira_comment)
         self.assertEqual(response.status_code, 200)

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -425,20 +425,24 @@ def jira_ticket(request_data):
                 ],
                 "summary": get_jira_title(request_data),
                 "description": get_jira_description(request_data),
-                "customfield_15602": "on"
-                if int(request_data.get("level", 0)) >= 100
-                else "off",
+                "customfield_15602": (
+                    "on" if int(request_data.get("level", 0)) >= 100 else "off"
+                ),
                 "customfield_16702": float(request_data.get("time_lost", 0)),
                 # Default values of the following fields are set to -1
                 "customfield_17204": {
-                    "id": str(primary_software_components_ids[0])
-                    if primary_software_components_ids
-                    else "-1"
+                    "id": (
+                        str(primary_software_components_ids[0])
+                        if primary_software_components_ids
+                        else "-1"
+                    )
                 },
                 "customfield_17205": {
-                    "id": str(primary_hardware_components_ids[0])
-                    if primary_hardware_components_ids
-                    else "-1"
+                    "id": (
+                        str(primary_hardware_components_ids[0])
+                        if primary_hardware_components_ids
+                        else "-1"
+                    )
                 },
             },
             "update": {
@@ -533,6 +537,32 @@ def jira_comment(request_data):
         },
         status=400,
     )
+
+
+def handle_jira_payload(request, lfa_urls=[]):
+    """Handle the JIRA payload and send it to the JIRA API
+
+    Parameters
+    ----------
+    request : Request
+        The request object
+    lfa_urls : list
+        List of urls of the files uploaded to the LFA
+        Which will be attached to the Jira ticket
+
+    Returns
+    -------
+    Response
+        The response and status code of the request to the JIRA API
+    """
+    payload_data = request.data.copy()
+    payload_data["user_agent"] = "LOVE"
+    payload_data["user_id"] = f"{request.user}@{request.get_host()}"
+    payload_data["lfa_files_urls"] = lfa_urls
+
+    if request.data.get("jira_new") == "true":
+        return jira_ticket(payload_data)
+    return jira_comment(payload_data)
 
 
 def get_client_ip(request):


### PR DESCRIPTION
This PR extends the `NarrativelogViewSet` and `ExposurelogViewSet` to allow JIRA ticket attachment on the `update` method.
Related to https://github.com/lsst-ts/LOVE-frontend/pull/604.