### PR TITLE
Update summary state fixture views with a new CSC: ESS:205

### DIFF
--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -1185,6 +1185,10 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 205
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 301
                     }
                   ],

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1689,6 +1689,10 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 205
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 301
                     }
                   ],

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -1185,6 +1185,10 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 205
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 301
                     }
                   ],


### PR DESCRIPTION
This PR adds the `ESS:205` CSC to the summary state views for Summit, BTS and TTS fixtures.