### PR TITLE
Adjustments for the JIRA Cloud REST API interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.17.3
+-------
+
+* Adjustments for new JIRA Cloud REST API interface `<https://github.com/lsst-ts/LOVE-manager/pull/239>`_
+
 v5.17.2
 -------
 

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -19,6 +19,7 @@
 
 
 import math
+import os
 import random
 from unittest.mock import patch
 
@@ -282,6 +283,7 @@ class JiraTestCase(TestCase):
         jira_response = jira_ticket(self.jira_request_narrative_without_param.data)
         assert "Error creating jira payload" in jira_response.data["ack"]
 
+    @patch.dict(os.environ, {"JIRA_API_HOSTNAME": "jira.lsstcorp.org"})
     def test_needed_parameters(self):
         """Test call to jira_ticket function with all needed parameters"""
         mock_jira_patcher = patch("requests.post")
@@ -294,12 +296,18 @@ class JiraTestCase(TestCase):
         jira_response = jira_ticket(self.jira_request_exposure_full.data)
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira ticket created"
-        assert jira_response.data["url"] == "https://jira.lsstcorp.org/browse/LOVE-XX"
+        assert (
+            jira_response.data["url"]
+            == f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/LOVE-XX"
+        )
 
         jira_response = jira_ticket(self.jira_request_narrative_full.data)
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira ticket created"
-        assert jira_response.data["url"] == "https://jira.lsstcorp.org/browse/LOVE-XX"
+        assert (
+            jira_response.data["url"]
+            == f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/LOVE-XX"
+        )
 
         mock_jira_patcher.stop()
 
@@ -319,6 +327,7 @@ class JiraTestCase(TestCase):
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira comment created"
 
+    @patch.dict(os.environ, {"JIRA_API_HOSTNAME": "jira.lsstcorp.org"})
     def test_handle_narrative_jira_payload(self):
         """Test call to function handle_jira_payload with all needed parameters
         for narrative request type
@@ -333,14 +342,20 @@ class JiraTestCase(TestCase):
         jira_response = handle_jira_payload(self.jira_request_narrative_full_jira_new)
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira ticket created"
-        assert jira_response.data["url"] == "https://jira.lsstcorp.org/browse/LOVE-XX"
+        assert (
+            jira_response.data["url"]
+            == f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/LOVE-XX"
+        )
 
         jira_response = handle_jira_payload(
             self.jira_request_narrative_full_jira_comment
         )
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira comment created"
-        assert jira_response.data["url"] == "https://jira.lsstcorp.org/browse/LOVE-XX"
+        assert (
+            jira_response.data["url"]
+            == f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/LOVE-XX"
+        )
 
         mock_jira_patcher.stop()
 
@@ -358,13 +373,19 @@ class JiraTestCase(TestCase):
         jira_response = handle_jira_payload(self.jira_request_exposure_full_jira_new)
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira ticket created"
-        assert jira_response.data["url"] == "https://jira.lsstcorp.org/browse/LOVE-XX"
+        assert (
+            jira_response.data["url"]
+            == f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/LOVE-XX"
+        )
 
         jira_response = handle_jira_payload(
             self.jira_request_exposure_full_jira_comment
         )
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira comment created"
-        assert jira_response.data["url"] == "https://jira.lsstcorp.org/browse/LOVE-XX"
+        assert (
+            jira_response.data["url"]
+            == f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/LOVE-XX"
+        )
 
         mock_jira_patcher.stop()

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -369,7 +369,13 @@ def get_jira_description(request_data):
 
 def jira_ticket(request_data):
     """Connect to the Rubin Observatory JIRA Cloud REST API to
-    create a ticket on a specific project.
+    create a ticket on the OBS project.
+
+    For details on the fields available for the JIRA Cloud REST API see:
+    - https://rubinobs.atlassian.net/rest/api/latest/field
+
+    For details on the OBS project see:
+    - https://rubinobs.atlassian.net/rest/api/latest/project/OBS
 
     For more information on the REST API endpoints refer to:
     - https://developer.atlassian.com/cloud/jira/platform/rest/v3
@@ -418,8 +424,8 @@ def jira_ticket(request_data):
     try:
         jira_payload = {
             "fields": {
-                "issuetype": {"id": 10065},
-                "project": {"id": os.environ.get("JIRA_PROJECT_ID")},
+                "issuetype": {"id": "10065"},
+                "project": {"id": "10037"},
                 "labels": [
                     "LOVE",
                     *tags_data,
@@ -427,7 +433,7 @@ def jira_ticket(request_data):
                 "summary": get_jira_title(request_data),
                 "description": get_jira_description(request_data),
                 # customfield_15602 which represents the URGENT flag
-                # is not yet migrated to the new JIRA cloud service.
+                # is not yet migrated to the new JIRA cloud OBS project.
                 # The following block is commented until the migration is done.
                 # TODO: DM-43066
                 # "customfield_15602": (
@@ -492,7 +498,7 @@ def jira_ticket(request_data):
 
 def jira_comment(request_data):
     """Connect to the Rubin Observatory JIRA Cloud REST API to
-    make a comment on a previously created ticket on a specific project.
+    make a comment on a previously created ticket.
 
     For more information on the REST API endpoints refer to:
     - https://developer.atlassian.com/cloud/jira/platform/rest/v3

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -368,12 +368,13 @@ def get_jira_description(request_data):
 
 
 def jira_ticket(request_data):
-    """Connects to JIRA API to create a ticket on a specific project.
-    For more information on issuetypes refer to:
-    https://jira.lsstcorp.org/rest/api/latest/issuetype/?projectId=JIRA_PROJECT_ID
+    """Connect to the Rubin Observatory JIRA Cloud REST API to
+    create a ticket on a specific project.
 
-    For more information on the issue creation payload refer to:
-    https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post
+    For more information on the REST API endpoints refer to:
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3
+    - https://developer.atlassian.com/cloud/jira/platform/\
+        basic-auth-for-rest-apis/
 
     Params
     ------
@@ -417,7 +418,7 @@ def jira_ticket(request_data):
     try:
         jira_payload = {
             "fields": {
-                "issuetype": {"id": 12302},
+                "issuetype": {"id": 10065},
                 "project": {"id": os.environ.get("JIRA_PROJECT_ID")},
                 "labels": [
                     "LOVE",
@@ -425,19 +426,24 @@ def jira_ticket(request_data):
                 ],
                 "summary": get_jira_title(request_data),
                 "description": get_jira_description(request_data),
-                "customfield_15602": (
-                    "on" if int(request_data.get("level", 0)) >= 100 else "off"
-                ),
-                "customfield_16702": float(request_data.get("time_lost", 0)),
+                # customfield_15602 which represents the URGENT flag
+                # is not yet migrated to the new JIRA cloud service.
+                # The following block is commented until the migration is done.
+                # TODO: DM-43066
+                # "customfield_15602": (
+                #     "on" if int(request_data.get("level", 0)) >= 100
+                #     else "off"
+                # ),
+                "customfield_10106": float(request_data.get("time_lost", 0)),
                 # Default values of the following fields are set to -1
-                "customfield_17204": {
+                "customfield_10107": {
                     "id": (
                         str(primary_software_components_ids[0])
                         if primary_software_components_ids
                         else "-1"
                     )
                 },
-                "customfield_17205": {
+                "customfield_10196": {
                     "id": (
                         str(primary_hardware_components_ids[0])
                         if primary_hardware_components_ids
@@ -485,10 +491,13 @@ def jira_ticket(request_data):
 
 
 def jira_comment(request_data):
-    """Connects to JIRA API to add a comment to
-    a previously created ticket on a specific project.
-    For more information on issuetypes refer to:
-    ttps://jira.lsstcorp.org/rest/api/latest/issuetype/?projectId=JIRA_PROJECT_ID
+    """Connect to the Rubin Observatory JIRA Cloud REST API to
+    make a comment on a previously created ticket on a specific project.
+
+    For more information on the REST API endpoints refer to:
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3
+    - https://developer.atlassian.com/cloud/jira/platform/\
+        basic-auth-for-rest-apis/
 
     Params
     ------

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -476,7 +476,7 @@ def jira_ticket(request_data):
         return Response(
             {
                 "ack": "Jira ticket created",
-                "url": f"https://jira.lsstcorp.org/browse/{response_data['key']}",
+                "url": f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/{response_data['key']}",
             },
             status=200,
         )
@@ -536,7 +536,7 @@ def jira_comment(request_data):
         return Response(
             {
                 "ack": "Jira comment created",
-                "url": f"https://jira.lsstcorp.org/browse/{jira_id}",
+                "url": f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/{jira_id}",
             },
             status=200,
         )


### PR DESCRIPTION
This PR makes a few adjustments to the `jira_ticket` and `jira_comment` functions in order to comply with the new parameters needed for the JIRA cloud service migration.