### PR TITLE
Update OBS jira project id and roll back way of setting it

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.17.4
+-------
+
+* Update OBS jira project id and roll back way of setting it `<https://github.com/lsst-ts/LOVE-manager/pull/240>`_
+
 v5.17.3
 -------
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -425,7 +425,11 @@ def jira_ticket(request_data):
         jira_payload = {
             "fields": {
                 "issuetype": {"id": "10065"},
-                "project": {"id": "10037"},
+                # If the JIRA_PROJECT_ID environment variable is not set,
+                # the project id is set to the OBS project by default: 10063.
+                # Set it in case the OBS project id has changed for any reason
+                # and update the default value above and in the following line.
+                "project": {"id": os.environ.get("JIRA_PROJECT_ID", "10063")},
                 "labels": [
                     "LOVE",
                     *tags_data,


### PR DESCRIPTION
This PR updates the Jira OBS project id due to a change on the recent migration to the cloud. The environment variable to configure the `JIRA_PROJECT_ID` was removed (93066aa206d61d1ccec3e5c813a35d57bcfc43e5) because we thought it didn't have a use case as fields are linked to the project (so a change on the project means a change in the code anyways). We realized the jira project id can change without changing its fields, so for these cases it would be useful to keep having a way of configuring the jira project id.