### PR TITLE
Add ScriptQueue:3 and Scheduler:3 to ASummary State View on Summit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.18.1
+-------
+
+* Add ScriptQueue:3 and Scheduler:3 to ASummary State View on Summit `<https://github.com/lsst-ts/LOVE-manager/pull/243>`_
+
 v5.18.0
 -------
 

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1706,12 +1706,20 @@
                       "salindex": 2
                     },
                     {
+                      "name": "ScriptQueue",
+                      "salindex": 3
+                    },
+                    {
                       "name": "Scheduler",
                       "salindex": 1
                     },
                     {
                       "name": "Scheduler",
                       "salindex": 2
+                    },
+                    {
+                      "name": "Scheduler",
+                      "salindex": 3
                     },
                     {
                       "name": "Watcher",


### PR DESCRIPTION
This PR adds two new CSCs: `ScriptQueue:3` and `Scheduler:3` to the ui_framework summit views fixture for persistence.