### PR TITLE
Add mailing feature so it can be used by the Night Report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.19.0
+-------
+
+* Add mailing feature so it can be used by the Night Report `<https://github.com/lsst-ts/LOVE-manager/pull/245>`_
+
 v5.18.1
 -------
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ All these variables are initialized with default variables defined in :code:`.en
 - `REMOTE_STORAGE`: defines if remote storage is used. If this variable is defined, then the LOVE-manager will connect to the LFA to upload files. If not defined, then the LOVE-manager will store the files locally.
 - `COMMANDING_PERMISSION_TYPE`: defines the type of permission to use for commanding. Currently two options are available: `user` and `location`. If `user` is used, then requests from users with `api.command.execute_command` permission are allowed. If `location` is used, then only requests from the configured location of control will be allowed. If not defined, then `user` will be used.
 - `URL_SUBPATH`: defines the path where the LOVE-manager will be served. If not defined, then requests will be served from the root path `/`. Note: the application has its own routing system, so this variable must be thought of as a prefix to the application's routes.
+- `SMTP_USER`: defines the user to use to send emails. The `@lsst.org` domain is added automatically.
+- `SMTP_PASSWORD`: defines the password for the `SMTP_USER`.
+- `NIGHTREPORT_MAIL_ADDRESS`: defines the email address to send the night report to. Default to `rubin-night-log@lists.lsst.org` if not defined.
 
 # Local load for development
 

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -561,6 +561,14 @@ class NightReportTestCase(TestCase):
         mock_ole_client_patch = mock_ole_patcher_patch.start()
         mock_ole_client_patch.return_value = response_patch
 
+        mock_get_jira_obs_report = patch("api.views.get_jira_obs_report")
+        mock_get_jira_obs_report_client = mock_get_jira_obs_report.start()
+        mock_get_jira_obs_report_client.return_value = []
+
+        mock_send_smtp_email = patch("api.views.send_smtp_email")
+        mock_send_smtp_email_client = mock_send_smtp_email.start()
+        mock_send_smtp_email_client.return_value = True
+
         self.client.credentials(
             HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
         )

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1643,8 +1643,14 @@ def ole_send_night_report(request, *args, **kwargs):
         )
 
     # Arrange HMTl email content
-    html_content = arrange_nightreport_email(report)
-    plain_content = arrange_nightreport_email(report, plain=True)
+    try:
+        html_content = arrange_nightreport_email(report)
+        plain_content = arrange_nightreport_email(report, plain=True)
+    except Exception as e:
+        return Response(
+            {"error": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
     # Handle email sending
     subject = f"{get_obsday_iso(report['day_obs'])} {report['telescope']} Night Log"

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -74,8 +74,10 @@ from manager.settings import (
 )
 from manager.utils import (
     CommandPermission,
+    arrange_nightreport_email,
     get_obsday_from_tai,
     handle_jira_payload,
+    send_smtp_email,
     upload_to_lfa,
 )
 
@@ -1629,8 +1631,14 @@ def ole_send_night_report(request, *args, **kwargs):
             {"error": "Night report already sent"}, status=status.HTTP_400_BAD_REQUEST
         )
 
-    # TODO: add email sending feature
-    # See: DM-43410
+    # Arrange HMTl email content
+    html_content = arrange_nightreport_email(report)
+    plain_content = arrange_nightreport_email(report, plain=True)
+
+    # Handle email sending
+    send_smtp_email(
+        "aranda.sebastian@gmail.com", "Night report sent", html_content, plain_content
+    )
 
     # Set date_sent
     curr_tai = astropy.time.Time.now().tai.datetime

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -77,6 +77,7 @@ from manager.utils import (
     arrange_nightreport_email,
     get_jira_obs_report,
     get_obsday_from_tai,
+    get_obsday_iso,
     handle_jira_payload,
     send_smtp_email,
     upload_to_lfa,
@@ -1640,9 +1641,8 @@ def ole_send_night_report(request, *args, **kwargs):
     plain_content = arrange_nightreport_email(report, plain=True)
 
     # Handle email sending
-    send_smtp_email(
-        "aranda.sebastian@gmail.com", "Rubin Night Log", html_content, plain_content
-    )
+    subject = f"{get_obsday_iso(report['day_obs'])} {report['telescope']} Night Log"
+    send_smtp_email("aranda.sebastian@gmail.com", subject, html_content, plain_content)
 
     # Set date_sent
     curr_tai = astropy.time.Time.now().tai.datetime

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -75,6 +75,7 @@ from manager.settings import (
 from manager.utils import (
     CommandPermission,
     arrange_nightreport_email,
+    get_jira_obs_report,
     get_obsday_from_tai,
     handle_jira_payload,
     send_smtp_email,
@@ -1631,13 +1632,16 @@ def ole_send_night_report(request, *args, **kwargs):
             {"error": "Night report already sent"}, status=status.HTTP_400_BAD_REQUEST
         )
 
+    obs_issues = get_jira_obs_report({"day_obs": report["day_obs"]})
+    report["obs_issues"] = obs_issues
+
     # Arrange HMTl email content
     html_content = arrange_nightreport_email(report)
     plain_content = arrange_nightreport_email(report, plain=True)
 
     # Handle email sending
     send_smtp_email(
-        "aranda.sebastian@gmail.com", "Night report sent", html_content, plain_content
+        "aranda.sebastian@gmail.com", "Rubin Night Log", html_content, plain_content
     )
 
     # Set date_sent

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1649,7 +1649,10 @@ def ole_send_night_report(request, *args, **kwargs):
     # Handle email sending
     subject = f"{get_obsday_iso(report['day_obs'])} {report['telescope']} Night Log"
     email_sent = send_smtp_email(
-        "aranda.sebastian@gmail.com", subject, html_content, plain_content
+        os.environ.get("NIGHTREPORT_MAIL_ADDRESS", "rubin-night-log@lists.lsst.org"),
+        subject,
+        html_content,
+        plain_content,
     )
     if not email_sent:
         return Response(

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -1025,6 +1025,8 @@ def parse_obs_issues_array_to_html_table(obs_issues):
     - reporter: The reporter of the issue
     - created: The creation date of the issue
 
+    If a key is missing, it will be replaced by a dash "-".
+
     Returns
     -------
     str
@@ -1045,11 +1047,11 @@ def parse_obs_issues_array_to_html_table(obs_issues):
     for issue in obs_issues:
         html_table += f"""
         <tr>
-            <td>{issue['key']}</td>
-            <td>{issue['summary']}</td>
-            <td>{issue['time_lost']}</td>
-            <td>{issue['reporter']}</td>
-            <td>{issue['created']}</td>
+            <td>{issue.get('key', '-')}</td>
+            <td>{issue.get('summary', '-')}</td>
+            <td>{issue.get('time_lost', '-')}</td>
+            <td>{issue.get('reporter', '-')}</td>
+            <td>{issue.get('created', '-')}</td>
         </tr>
         """
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -827,7 +827,7 @@ def send_smtp_email(to, subject, html_content, plain_content):
         msg["From"] = f"{os.environ.get('SMTP_USER')}@lsst.org"
         msg["To"] = to
 
-        s = smtplib.SMTP("mail.lsst.org", "587")
+        s = smtplib.SMTP("exch-ls.lsst.org", "587")
         s.starttls()
         s.login(os.environ.get("SMTP_USER"), os.environ.get("SMTP_PASSWORD"))
         s.sendmail(msg["From"], msg["To"], msg.as_string())

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -883,6 +883,19 @@ def arrange_nightreport_email(report, plain=False):
         The night report email in HTML format or plain text format
     """
 
+    expected_keys = [
+        "telescope",
+        "day_obs",
+        "summary",
+        "telescope_status",
+        "confluence_url",
+        "obs_issues",
+        "observers_crew",
+    ]
+    missing_keys = [key for key in expected_keys if key not in report]
+    if missing_keys:
+        raise ValueError(f"Missing keys in report: {', '.join(missing_keys)}")
+
     url_jira_obs_tickets = (
         "https://rubinobs.atlassian.net/jira/software/c/projects/OBS/boards/232"
     )

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -594,20 +594,8 @@ def get_jira_obs_report(request_data):
     Then get the total observation time loss from the time_lost param
     """
 
-    initial_day_obs_string = (
-        str(request_data.get("day_obs"))[:4]
-        + "-"
-        + str(request_data.get("day_obs"))[4:6]
-        + "-"
-        + str(request_data.get("day_obs"))[6:8]
-    )
-    final_day_obs_string = (
-        str(request_data.get("day_obs") + 1)[:4]
-        + "-"
-        + str(request_data.get("day_obs") + 1)[4:6]
-        + "-"
-        + str(request_data.get("day_obs") + 1)[6:8]
-    )
+    initial_day_obs_string = get_obsday_iso(request_data.get("day_obs"))
+    final_day_obs_string = get_obsday_iso(request_data.get("day_obs") + 1)
 
     # JQL query to find issues created on a specific date
     jql_query = (
@@ -682,6 +670,22 @@ def get_obsday_from_tai(tai):
     if tai.hour < 12:
         observing_day = (tai - timedelta(days=1)).strftime("%Y%m%d")
     return observing_day
+
+
+def get_obsday_iso(obsday):
+    """Return the observing day in ISO format.
+
+    Parameters
+    ----------
+    obsday : `int`
+        The observing day in the format "YYYYMMDD" as an integer
+
+    Returns
+    -------
+    String
+        The observing day in ISO format
+    """
+    return f"{str(obsday)[:4]}-{str(obsday)[4:6]}-{str(obsday)[6:8]}"
 
 
 def get_tai_to_utc() -> float:
@@ -867,7 +871,7 @@ def arrange_nightreport_email(report, plain=False):
     url_jira_obs_tickets = (
         "https://rubinobs.atlassian.net/jira/software/c/projects/OBS/boards/232"
     )
-    day_added = report["date_added"].split("T")[0]
+    day_added = get_obsday_iso(report["day_obs"])
 
     # TODO: Swap this hardcoded url by a dynamic one.
     # The service is meant to be run in the summit,
@@ -902,6 +906,21 @@ def arrange_nightreport_email(report, plain=False):
     <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <style>
+            table {{
+                font-family: Arial, sans-serif;
+                border-collapse: collapse;
+                width: 100%;
+            }}
+            th {{
+                background-color: #f2f2f2;
+            }}
+            th, td {{
+                border: 1px solid #dddddd;
+                text-align: left;
+                padding: 8px;
+            }}
+        </style>
     </head>
     <body>
         <p>

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -894,23 +894,40 @@ def arrange_nightreport_email(report, plain=False):
     # See: DM-43637
     url_rolex = f"https://summit-lsp.lsst.codes/rolex?log_date={day_added}"
 
+    WELCOME_MSG = "Hello everyone!"
+    INTRODUCTION_MSG = (
+        "Please find below a summary of the observing night"
+        " and links for more detailed information."
+    )
+    SUMMARY_TITLE = "Summary:"
+    FINAL_TELESCOPE_STATUS_TITLE = "Final telescope status:"
+    ADDITIONAL_RESOURCES_TITLE = "Additional resources:"
+    SIGNED_MSG = "Signed, your friendly neighborhood observers,"
+    LINK_MSG_OBS = "OBS fault reports from last 24 hours:"
+    LINK_MSG_CONFLUENCE = f"Link to {report['telescope']} Log Confluence Page:"
+    LINK_MSG_ROLEX = "Link to detailed night log entries (requires Summit VPN):"
+    DETAILED_ISSUE_REPORT_TITLE = "Detailed issue report:"
+    TOTAL_TIME_LOST_MSG = (
+        "Total obstime loss: "
+        f"{sum([issue['time_lost'] for issue in report['obs_issues']])} hours"
+    )
     if plain:
         plain_content = f"""
-        Hello everyone!
-        Please find below a summary of the observing night and links for more detailed information.
-        Summary:
+        {WELCOME_MSG}
+        {INTRODUCTION_MSG}
+        {SUMMARY_TITLE}
         {report["summary"]}
-        Final telescope status:
+        {FINAL_TELESCOPE_STATUS_TITLE}
         {report["telescope_status"]}
-        Additional resources:
-        - OBS fault reports from last 24 hours: {url_jira_obs_tickets}
-        - Link to {report["telescope"]} Log Confluence Page: {report["confluence_url"]}
-        - Link to detailed night log entries (requires Summit VPN): {url_rolex}
-        {f'''Detailed issue report:
+        {ADDITIONAL_RESOURCES_TITLE}
+        - {LINK_MSG_OBS} {url_jira_obs_tickets}
+        - {LINK_MSG_CONFLUENCE} {report["confluence_url"]}
+        - {LINK_MSG_ROLEX} {url_rolex}
+        {f'''{DETAILED_ISSUE_REPORT_TITLE}
         {report["obs_issues"]}
-        Total obstime loss: {sum([issue['time_lost'] for issue in report["obs_issues"]])} hours
+        {TOTAL_TIME_LOST_MSG}
         ''' if len(report["obs_issues"]) > 0 else ""}
-        Signed, your friendly neighborhood observers,
+        {SIGNED_MSG}
         {report["observers_crew"]}
         """
         return plain_content
@@ -939,47 +956,47 @@ def arrange_nightreport_email(report, plain=False):
     </head>
     <body>
         <p>
-            Hello everyone!
+            {WELCOME_MSG}
             <br>
-            Please find below a summary of the observing night and links for more detailed information.
+            {INTRODUCTION_MSG}
         </p>
         <p>
-            Summary:
+            {SUMMARY_TITLE}
             <br>
             {report["summary"].replace(new_line_character, '<br>')}
         </p>
         <p>
-            Final telescope status:
+            {FINAL_TELESCOPE_STATUS_TITLE}
             <br>
             {report["telescope_status"].replace(new_line_character, '<br>')}
         </p>
         <p>
-            Additional resources:
+            {ADDITIONAL_RESOURCES_TITLE}
             <br>
             <ul>
                 <li>
-                    OBS fault reports from last 24 hours:
+                    {LINK_MSG_OBS}
                     <a href="{url_jira_obs_tickets}">{url_jira_obs_tickets}</a>
                 </li>
                 <li>
-                    Link to {report["telescope"]} Log Confluence Page:
+                    {LINK_MSG_CONFLUENCE}
                     <a href="{report["confluence_url"]}">{report["confluence_url"]}</a>
                 </li>
                 <li>
-                    Link to detailed night log entries (requires Summit VPN):
+                    {LINK_MSG_ROLEX}
                     <a href="{url_rolex}">{url_rolex}</a>
                 </li>
             </ul>
         </p>
         {f'''<p>
-            Detailed issue report:
+            {DETAILED_ISSUE_REPORT_TITLE}
             <br>
             {parse_obs_issues_array_to_html_table(report["obs_issues"])}
             <br>
-            Total obstime loss: {sum([issue['time_lost'] for issue in report["obs_issues"]])} hours
+            {TOTAL_TIME_LOST_MSG}
         </p>''' if len(report["obs_issues"]) > 0 else ""}
         <p>
-            Signed, your friendly neighborhood observers,
+            {SIGNED_MSG}
             <br>
             {", ".join(report["observers_crew"])}
         </p>

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -837,6 +837,7 @@ def arrange_nightreport_email(report, plain=False):
         """
         return plain_content
 
+    new_line_character = "\n"
     html_content = f"""
     <!DOCTYPE html>
     <html lang="en">
@@ -852,12 +853,12 @@ def arrange_nightreport_email(report, plain=False):
         <p>
             Summary:
             <br>
-            {report["summary"]}
+            {report["summary"].replace(new_line_character, '<br>')}
         </p>
         <p>
             Final telescope status:
             <br>
-            {report["telescope_status"]}
+            {report["telescope_status"].replace(new_line_character, '<br>')}
         </p>
         <p>
             Additional resources:


### PR DESCRIPTION
This PR adds several functions in order to allow sending the defined night summary report to a specific email address. Configurations were set to provide an user and password for sending emails through a SMTP server. Now when confirming a night report, its information will be gathered and sent to the specified email address set on `NIGHTREPORT_MAIL_ADDRESS` environment variable.