### PR TITLE
Fix API fixture to point to correct default LOVE configuration file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.19.2
+-------
+
+* Fix API fixture to point to correct default LOVE configuration file `<https://github.com/lsst-ts/LOVE-manager/pull/250>`_
+
 v5.19.1
 -------
 

--- a/manager/api/fixtures/initial_data_remote_summit.json
+++ b/manager/api/fixtures/initial_data_remote_summit.json
@@ -7,7 +7,7 @@
       "update_timestamp": "2020-12-29T14:21:31.040Z",
       "user": 1,
       "file_name": "default.json",
-      "config_file": "http://love01.cp.lsst.org/media/configs/default.json"
+      "config_file": "https://summit-lsp.lsst.codes/love/media/configs/default.json"
     }
   },
   {


### PR DESCRIPTION
This PR edits the `manager/api/fixtures/initial_data_remote_summit.json` file in order to properly set the default LOVE configuration file. This was a missing change we just realized now when LOVE01 BM was down as the deployment was trying to access an endpoint that was not being served, hence resulting in login errors as the login feature queries this default LOVE configuration file.