### PR TITLE
Add OCPS:101 to ASummary State View on Summit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.0.2
 ------
 
+* Add OCPS:101 to ASummary State View on Summit `<https://github.com/lsst-ts/LOVE-manager/pull/258>`_
 * Bump django from 3.1.14 to 3.2.25 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/257>`_
 
 v6.0.1

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1742,6 +1742,10 @@
                       "salindex": 2
                     },
                     {
+                      "name": "OCPS",
+                      "salindex": 101
+                    },
+                    {
                       "name": "GIS",
                       "salindex": 0
                     }


### PR DESCRIPTION
This PR adds the `OCPS:101` CSC to the ASummary State View on the summit `ui_framework` fixtures.