### PR TITLE
Remove unused dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.0.4
+------
+
+* Remove unused dependencies `<https://github.com/lsst-ts/LOVE-manager/pull/261>`_
+
 v6.0.3
 ------
 

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -26,7 +26,6 @@ djangorestframework==3.11.2
 docutils==0.16
 drf-yasg==1.17.1
 entrypoints==0.3
-flake8==3.7.9
 freezegun==0.3.15
 hiredis==1.0.1
 hyperlink==19.0.0

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -38,7 +38,6 @@ inflection==0.3.1
 itypes==1.1.0
 Jinja2==2.11.3
 jsonschema==3.2.0
-m2r==0.2.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune<2.0.0
@@ -72,14 +71,6 @@ ruamel.yaml==0.16.10
 ruamel.yaml.clib==0.2.0
 six==1.14.0
 snowballstemmer==2.0.0
-Sphinx==2.4.4
-sphinx-rtd-theme==0.4.3
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==1.0.3
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.4
 sqlparse==0.4.4
 Twisted==23.10.0
 txaio==20.1.1


### PR DESCRIPTION
This PR removes some dependencies from the `manager/requirements.txt` as they were not really been used by the consumers of that file. Dependencies for documentation were removed as they are already set on `docsrc/requirements.txt` and also `flake8` was removed as it is being installed using `pre-commit` hooks.