### PR TITLE
Remove time loss calculation from nightreport mailing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.0.4
 ------
 
+* Remove time loss calculation from nightreport mailing `<https://github.com/lsst-ts/LOVE-manager/pull/262>`_
 * Remove unused dependencies `<https://github.com/lsst-ts/LOVE-manager/pull/261>`_
 
 v6.0.3

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -915,10 +915,7 @@ def arrange_nightreport_email(report, plain=False):
     LINK_MSG_CONFLUENCE = f"Link to {report['telescope']} Log Confluence Page:"
     LINK_MSG_ROLEX = "Link to detailed night log entries (requires Summit VPN):"
     DETAILED_ISSUE_REPORT_TITLE = "Detailed issue report:"
-    TOTAL_TIME_LOST_MSG = (
-        "Total obstime loss: "
-        f"{sum([issue['time_lost'] for issue in report['obs_issues']])} hours"
-    )
+
     if plain:
         plain_content = f"""{SUMMARY_TITLE}
 {report["summary"]}
@@ -930,7 +927,6 @@ def arrange_nightreport_email(report, plain=False):
 - {LINK_MSG_ROLEX} {url_rolex}
 {f'''{DETAILED_ISSUE_REPORT_TITLE}
 {parse_obs_issues_array_to_plain_text(report["obs_issues"])}
-{TOTAL_TIME_LOST_MSG}
 ''' if len(report["obs_issues"]) > 0 else ""}
 {SIGNED_MSG}
 {", ".join(report["observers_crew"])}"""
@@ -991,8 +987,6 @@ def arrange_nightreport_email(report, plain=False):
             {DETAILED_ISSUE_REPORT_TITLE}
             <br>
             {parse_obs_issues_array_to_html_table(report["obs_issues"])}
-            <br>
-            {TOTAL_TIME_LOST_MSG}
         </p>''' if len(report["obs_issues"]) > 0 else ""}
         <p>
             {SIGNED_MSG}

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -919,15 +919,19 @@ def arrange_nightreport_email(report, plain=False):
     if plain:
         plain_content = f"""{SUMMARY_TITLE}
 {report["summary"]}
+
 {FINAL_TELESCOPE_STATUS_TITLE}
 {report["telescope_status"]}
+
 {ADDITIONAL_RESOURCES_TITLE}
 - {LINK_MSG_OBS} {url_jira_obs_tickets}
 - {LINK_MSG_CONFLUENCE} {report["confluence_url"]}
 - {LINK_MSG_ROLEX} {url_rolex}
-{f'''{DETAILED_ISSUE_REPORT_TITLE}
+{f'''
+{DETAILED_ISSUE_REPORT_TITLE}
 {parse_obs_issues_array_to_plain_text(report["obs_issues"])}
 ''' if len(report["obs_issues"]) > 0 else ""}
+
 {SIGNED_MSG}
 {", ".join(report["observers_crew"])}"""
         return plain_content

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -1031,7 +1031,6 @@ def parse_obs_issues_array_to_html_table(obs_issues):
         <tr>
             <th>Key</th>
             <th>Summary</th>
-            <th>Time Lost (hours)</th>
             <th>Reporter</th>
             <th>Created</th>
         </tr>
@@ -1042,7 +1041,6 @@ def parse_obs_issues_array_to_html_table(obs_issues):
         <tr>
             <td>{issue.get('key', '-')}</td>
             <td>{issue.get('summary', '-')}</td>
-            <td>{issue.get('time_lost', '-')}</td>
             <td>{issue.get('reporter', '-')}</td>
             <td>{issue.get('created', '-')}</td>
         </tr>
@@ -1081,6 +1079,6 @@ def parse_obs_issues_array_to_plain_text(obs_issues):
     plain_text = ""
     for issue in obs_issues:
         plain_text += f"{issue.get('key')} - {issue.get('summary')}: "
-        plain_text += f"Created by {issue.get('reporter')} - Lost {issue.get('time_lost')} hours\n"
+        plain_text += f"Created by {issue.get('reporter')}\n"
 
     return plain_text


### PR DESCRIPTION
This PR removes the time loss calculation of OBS jira tickets as it was currently missleading. Two mails are sent at the end of the night, on for AuxTel and one for Simonyi, however both mails have a exact same replicate of the jira tickets list, with its time loss details. This was missleading, as time loss could apply only for one telescope and not both. However this is a complex problem which needs to be discussed, but for the moment we are just removing the time loss detail to avoid confusions.