### PR TITLE
Strip white spaces from human written fields in the ole_send_night_report function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.0.5
+------
+
+* Strip white spaces from human written fields in the ole_send_night_report function `<https://github.com/lsst-ts/LOVE-manager/pull/265>`_
+
 v6.0.4
 ------
 

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1441,6 +1441,10 @@ def ole_send_night_report(request, *args, **kwargs):
             {"error": "Night report already sent"}, status=status.HTTP_400_BAD_REQUEST
         )
 
+    # Trim white spaces from human written fields from the report
+    for key in ["summary", "telescope_status", "confluence_url"]:
+        report[key] = report[key].strip()
+
     # Get JIRA observation issues
     try:
         report["obs_issues"] = get_jira_obs_report({"day_obs": report["day_obs"]})


### PR DESCRIPTION
This PR adds a white space stripping step in the `ole_send_night_report` function in order to remove empty spaces at the beginning and end of human written fields. This will be done on the final step of a night report before being sent as an email.