### PR TITLE
Add Electrometer:101 and Electrometer:102 to Summit ASummary State View

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.0.6
+------
+
+* Add Electrometer:101 and Electrometer:102 to Summit ASummary State View `<https://github.com/lsst-ts/LOVE-manager/pull/266>`_
+
 v6.0.5
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1855,7 +1855,11 @@
                   "Calibration Systems": [
                     {
                       "name": "Electrometer",
-                      "salindex": 1
+                      "salindex": 101
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 102
                     },
                     {
                       "name": "TunableLaser",


### PR DESCRIPTION
This PR replaces the `Electrometer:1` by `Electrometer:101` and also adds the `Electrometer:102` to the Summit `ASummary State View`.