### PR TITLE
Add CBP:0 to Summit ASummary State View

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.0.6
 ------
 
+* Add CBP:0 to Summit ASummary State View `<https://github.com/lsst-ts/LOVE-manager/pull/267>`_
 * Add Electrometer:101 and Electrometer:102 to Summit ASummary State View `<https://github.com/lsst-ts/LOVE-manager/pull/266>`_
 
 v6.0.5

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1854,6 +1854,10 @@
                   ],
                   "Calibration Systems": [
                     {
+                      "name": "CBP",
+                      "salindex": 0
+                    },
+                    {
                       "name": "Electrometer",
                       "salindex": 101
                     },


### PR DESCRIPTION
This PR add the `CBP:0` CSC to the Summit `ASummary State View`.