### PR TITLE
Remove conditional on authentication views that prevented commanding permissions to be overwritten

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.0.7
+------
+
+* Remove conditional on authentication views that prevented commanding permissions to be overwritten `<https://github.com/lsst-ts/LOVE-manager/pull/268>`_
+
 v6.0.6
 ------
 

--- a/manager/api/tests/test_auth_api.py
+++ b/manager/api/tests/test_auth_api.py
@@ -200,11 +200,12 @@ class AuthApiTestCase(TestCase):
             "The config was not requested",
         )
 
+    @patch("api.views.AUTH_LDAP_1_SERVER_URI", return_value="ldap://test/")
     @patch("django_auth_ldap.backend._LDAPUser", return_value=MockLDAPUserCommands())
     @patch("ldap.initialize", return_value=ldap.ldapobject.LDAPObject("ldap://test/"))
     @patch("ldap.ldapobject.LDAPObject.search_s", return_value=LDAP_SEARCH_RESPONSE)
     def test_ldap_nonexistent_cmd_user_login(
-        self, mockLDAPObject, mockLDAPInitialize, mockLDAPUser
+        self, mockLDAPObject, mockLDAPInitialize, mockLDAPUser, mockLDAPServerUri
     ):
         # Arrange:
         data = {"username": LDAP_USERNAME, "password": "password"}
@@ -230,11 +231,12 @@ class AuthApiTestCase(TestCase):
         self.assertEqual(user_group_cmd.name, "cmd")
         self.assertEqual(user_group_ui_framework.name, "ui_framework")
 
+    @patch("api.views.AUTH_LDAP_1_SERVER_URI", return_value="ldap://test/")
     @patch("django_auth_ldap.backend._LDAPUser", return_value=MockLDAPUserExistent())
     @patch("ldap.initialize", return_value=ldap.ldapobject.LDAPObject("ldap://test/"))
     @patch("ldap.ldapobject.LDAPObject.search_s", return_value=LDAP_SEARCH_RESPONSE)
     def test_ldap_existent_cmd_user_login(
-        self, mockLDAPObject, mockLDAPInitialize, mockLDAPUser
+        self, mockLDAPObject, mockLDAPInitialize, mockLDAPUser, mockLDAPServerUri
     ):
         # Arrange:
         data = {"username": LDAP_USERNAME_EXISTENT, "password": "password"}
@@ -260,6 +262,7 @@ class AuthApiTestCase(TestCase):
         self.assertEqual(user_group_cmd.name, "cmd")
         self.assertEqual(user_group_ui_framework.name, "ui_framework")
 
+    @patch("api.views.AUTH_LDAP_1_SERVER_URI", return_value="ldap://test/")
     @patch("django_auth_ldap.backend._LDAPUser", return_value=MockLDAPUserNonCommands())
     @patch("ldap.initialize", return_value=ldap.ldapobject.LDAPObject("ldap://test/"))
     @patch(
@@ -267,7 +270,7 @@ class AuthApiTestCase(TestCase):
         return_value=LDAP_SEARCH_RESPONSE,
     )
     def test_ldap_nonexistent_non_cmd_user_login(
-        self, mockLDAPObject, mockLDAPInitialize, mockLDAPUserNonCmd
+        self, mockLDAPObject, mockLDAPInitialize, mockLDAPUserNonCmd, mockLDAPServerUri
     ):
         # Arrange:
         data = {"username": LDAP_USERNAME_NON_COMMANDS, "password": "password"}

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -231,8 +231,6 @@ class CustomObtainAuthToken(ObtainAuthToken):
             The response containing the token and other user data.
         """
         username = request.data["username"]
-        user_aux = User.objects.filter(username=username).first()
-
         serializer = self.serializer_class(
             data=request.data, context={"request": request}
         )
@@ -240,13 +238,12 @@ class CustomObtainAuthToken(ObtainAuthToken):
         user_obj = serializer.validated_data["user"]
 
         ldap_result = None
-        if user_aux is None:
-            if IPABackend1.successful_login:
-                ldap_result = ldap.initialize(AUTH_LDAP_1_SERVER_URI)
-            elif IPABackend2.successful_login:
-                ldap_result = ldap.initialize(AUTH_LDAP_2_SERVER_URI)
-            elif IPABackend3.successful_login:
-                ldap_result = ldap.initialize(AUTH_LDAP_3_SERVER_URI)
+        if IPABackend1.successful_login:
+            ldap_result = ldap.initialize(AUTH_LDAP_1_SERVER_URI)
+        elif IPABackend2.successful_login:
+            ldap_result = ldap.initialize(AUTH_LDAP_2_SERVER_URI)
+        elif IPABackend3.successful_login:
+            ldap_result = ldap.initialize(AUTH_LDAP_3_SERVER_URI)
 
         baseDN = "cn=love_ops,cn=groups,cn=compat,dc=lsst,dc=cloud"
         searchScope = ldap.SCOPE_SUBTREE
@@ -316,8 +313,6 @@ class CustomSwapAuthToken(ObtainAuthToken):
             The response containing the token and other user data.
         """
         username = request.data["username"]
-        user_aux = User.objects.filter(username=username).first()
-
         if not request.user.is_authenticated or not request._auth:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         serializer = self.serializer_class(
@@ -327,13 +322,12 @@ class CustomSwapAuthToken(ObtainAuthToken):
         user_obj = serializer.validated_data["user"]
 
         ldap_result = None
-        if user_aux is None:
-            if IPABackend1.successful_login:
-                ldap_result = ldap.initialize(AUTH_LDAP_1_SERVER_URI)
-            elif IPABackend2.successful_login:
-                ldap_result = ldap.initialize(AUTH_LDAP_2_SERVER_URI)
-            elif IPABackend3.successful_login:
-                ldap_result = ldap.initialize(AUTH_LDAP_3_SERVER_URI)
+        if IPABackend1.successful_login:
+            ldap_result = ldap.initialize(AUTH_LDAP_1_SERVER_URI)
+        elif IPABackend2.successful_login:
+            ldap_result = ldap.initialize(AUTH_LDAP_2_SERVER_URI)
+        elif IPABackend3.successful_login:
+            ldap_result = ldap.initialize(AUTH_LDAP_3_SERVER_URI)
 
         baseDN = "cn=love_ops,cn=groups,cn=compat,dc=lsst,dc=cloud"
         searchScope = ldap.SCOPE_SUBTREE

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -167,6 +167,8 @@ class IPABackend1(LDAPBackend):
         user = ldap_user.authenticate(password)
         if user:
             IPABackend1.successful_login = True
+        else:
+            IPABackend1.successful_login = False
         return user
 
 
@@ -178,6 +180,8 @@ class IPABackend2(LDAPBackend):
         user = ldap_user.authenticate(password)
         if user:
             IPABackend2.successful_login = True
+        else:
+            IPABackend2.successful_login = False
         return user
 
 
@@ -189,6 +193,8 @@ class IPABackend3(LDAPBackend):
         user = ldap_user.authenticate(password)
         if user:
             IPABackend3.successful_login = True
+        else:
+            IPABackend3.successful_login = False
         return user
 
 
@@ -238,11 +244,11 @@ class CustomObtainAuthToken(ObtainAuthToken):
         user_obj = serializer.validated_data["user"]
 
         ldap_result = None
-        if IPABackend1.successful_login:
+        if AUTH_LDAP_1_SERVER_URI and IPABackend1.successful_login:
             ldap_result = ldap.initialize(AUTH_LDAP_1_SERVER_URI)
-        elif IPABackend2.successful_login:
+        elif AUTH_LDAP_2_SERVER_URI and IPABackend2.successful_login:
             ldap_result = ldap.initialize(AUTH_LDAP_2_SERVER_URI)
-        elif IPABackend3.successful_login:
+        elif AUTH_LDAP_3_SERVER_URI and IPABackend3.successful_login:
             ldap_result = ldap.initialize(AUTH_LDAP_3_SERVER_URI)
 
         baseDN = "cn=love_ops,cn=groups,cn=compat,dc=lsst,dc=cloud"
@@ -322,11 +328,11 @@ class CustomSwapAuthToken(ObtainAuthToken):
         user_obj = serializer.validated_data["user"]
 
         ldap_result = None
-        if IPABackend1.successful_login:
+        if AUTH_LDAP_1_SERVER_URI and IPABackend1.successful_login:
             ldap_result = ldap.initialize(AUTH_LDAP_1_SERVER_URI)
-        elif IPABackend2.successful_login:
+        elif AUTH_LDAP_2_SERVER_URI and IPABackend2.successful_login:
             ldap_result = ldap.initialize(AUTH_LDAP_2_SERVER_URI)
-        elif IPABackend3.successful_login:
+        elif AUTH_LDAP_3_SERVER_URI and IPABackend3.successful_login:
             ldap_result = ldap.initialize(AUTH_LDAP_3_SERVER_URI)
 
         baseDN = "cn=love_ops,cn=groups,cn=compat,dc=lsst,dc=cloud"


### PR DESCRIPTION
This PR makes a small change on the feature that authenticate users against the IPA servers. Initially this was designed to only write commanding permissions (for users in the IPA `love_ops` group) when the user haven't loged into LOVE yet, this for allowing administrators to manually remove permissions on demand as needed. However, usage has shown that most of users ask to be added to the `love_ops` group after they have logged in and also there hasn't been the need to be manually removing permissions. Hence this PR removes the conditional that prevented this to happen.