### PR TITLE
Remove deprecated deployment stages from the Jenkinsfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.0.0
 ------
 
+* Remove deprecated deployment stages from the Jenkinsfile `<https://github.com/lsst-ts/LOVE-manager/pull/274>`_
 * Bump requests from 2.31.0 to 2.32.2 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/273>`_
 * Bump django from 5.0.7 to 5.0.8 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/272>`_
 * Bump zipp from 3.1.0 to 3.19.1 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/264>`_

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,22 +115,5 @@ pipeline {
         }
       }
     }
-
-    stage("Trigger develop deployment") {
-      when {
-        branch "develop"
-      }
-      steps {
-        build(job: '../LOVE-integration-tools/develop', wait: false)
-      }
-    }
-    stage("Trigger main deployment") {
-      when {
-        branch "main"
-      }
-      steps {
-        build(job: '../LOVE-integration-tools/main', wait: false)
-      }
-    }
   }
 }


### PR DESCRIPTION
This PR removes a couple stages that were used to make deployments on a development environment used by Inria, however this is not being used anymore.