### PR TITLE
Accumulate Time Lost from comments sent through LOVE 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.0.2
+------
+
+* Add accumulation of time lost in Jira comments
+
 v7.0.1
 ------
 

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -316,21 +316,17 @@ class JiraTestCase(TestCase):
 
         mock_jira_patcher.stop()
 
-    def test_update_time_loss(self):
+    @patch("requests.get")
+    @patch("requests.put")
+    def test_update_time_loss(self, mock_get, mock_put):
         """Test call to update_time_loss and verify field was updated"""
         # patch both requests.get, requests.put
-        mock_jira_patcher = patch("requests.get")
-        mock_jira_client = mock_jira_patcher.start()
         response = requests.Response()
         response.status_code = 200
-        response.json = lambda: {"customfield_10106": 13.6}
-        mock_jira_client.return_value = response
+        mock_put.return_value = response
 
-        mock_jira_patcher = patch("requests.put")
-        mock_jira_client = mock_jira_patcher.start()
-        response = requests.Response()
-        response.status_code = 200
-        mock_jira_client.return_value = response
+        response.json = lambda: {"customfield_10106": 13.6}
+        mock_get.return_value = response
 
         # call update time lost
         jira_response = update_time_loss(1, 3.4)

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -366,6 +366,22 @@ class JiraTestCase(TestCase):
         assert jira_response.status_code == 200
         assert jira_response.data["ack"] == "Jira comment created"
 
+    def test_add_comment_fail(self):
+        mock_jira_patcher = patch("requests.post")
+        mock_jira_client = mock_jira_patcher.start()
+        response = requests.Response()
+        response.status_code = 201
+        mock_jira_client.return_value = response
+
+        mock_time_lost_patcher = patch("manager.utils.update_time_lost")
+        mock_time_lost_client = mock_time_lost_patcher.start()
+        time_response = requests.Response()
+        time_response.status_code = 400
+        mock_time_lost_client.return_value = time_response
+
+        resp = jira_comment(self.jira_request_narrative_full_jira_comment.data)
+        assert resp.status_code == 400
+
     @patch.dict(os.environ, {"JIRA_API_HOSTNAME": "jira.lsstcorp.org"})
     def test_handle_narrative_jira_payload(self):
         """Test call to function handle_jira_payload with all needed parameters
@@ -377,6 +393,12 @@ class JiraTestCase(TestCase):
         response.status_code = 201
         response.json = lambda: {"key": "LOVE-XX"}
         mock_jira_client.return_value = response
+
+        mock_time_lost_patcher = patch("manager.utils.update_time_lost")
+        mock_time_lost_client = mock_time_lost_patcher.start()
+        time_response = requests.Response()
+        time_response.status_code = 200
+        mock_time_lost_client.return_value = time_response
 
         jira_response = handle_jira_payload(self.jira_request_narrative_full_jira_new)
         assert jira_response.status_code == 200

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -600,9 +600,11 @@ def jira_comment(request_data):
     response = requests.post(url, json=jira_payload, headers=headers)
 
     if "time_lost" in request_data:
-        update_time_loss(
+        response = update_time_loss(
             jira_id=jira_id, add_time_loss=request_data.get("time_lost", 0.0)
         )
+        if response.status_code == 400:
+            return response
 
     if response.status_code == 201:
         return Response(

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -517,7 +517,7 @@ def update_time_loss(jira_id: int, add_time_loss: float = 0.0) -> Response:
     Returns
     -------
     Response
-        define response here
+        The response and status code of the request to the JIRA API
     """
     headers = {
         "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -603,11 +603,11 @@ def jira_comment(request_data):
     response = requests.post(url, json=jira_payload, headers=headers)
 
     if "time_lost" in request_data:
-        response = update_time_lost(
+        timelost_response = update_time_lost(
             jira_id=jira_id, add_time_lost=request_data.get("time_lost", 0.0)
         )
-        if response.status_code == 400:
-            return response
+        if timelost_response.status_code == 400:
+            return timelost_response
 
     if response.status_code == 201:
         return Response(

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -40,6 +40,9 @@ from rest_framework.response import Response
 # Constants
 JSON_RESPONSE_LOCAL_STORAGE_NOT_ALLOWED = {"error": "Local storage not allowed."}
 JSON_RESPONSE_ERROR_NOT_VALID_JSON = {"error": "Not a valid JSON response."}
+TIME_LOST_FIELD = "customfield_10106"
+PRIMARY_SOFTWARE_COMPONENTS_IDS = "customfield_10107"
+PRIMARY_HARDWARE_COMPONENTS_IDS = "customfield_10196"
 
 
 class LocationPermission(BasePermission):
@@ -449,16 +452,16 @@ def jira_ticket(request_data):
                 #     "on" if int(request_data.get("level", 0)) >= 100
                 #     else "off"
                 # ),
-                "customfield_10106": float(request_data.get("time_lost", 0)),
+                TIME_LOST_FIELD: float(request_data.get("time_lost", 0)),
                 # Default values of the following fields are set to -1
-                "customfield_10107": {
+                PRIMARY_SOFTWARE_COMPONENTS_IDS: {
                     "id": (
                         str(primary_software_components_ids[0])
                         if primary_software_components_ids
                         else "-1"
                     )
                 },
-                "customfield_10196": {
+                PRIMARY_HARDWARE_COMPONENTS_IDS: {
                     "id": (
                         str(primary_hardware_components_ids[0])
                         if primary_hardware_components_ids
@@ -505,45 +508,45 @@ def jira_ticket(request_data):
     )
 
 
-def update_time_loss(jira_id: int, add_time_loss: float = 0.0) -> Response:
+def update_time_lost(jira_id: int, add_time_lost: float = 0.0) -> Response:
     """Connect to the Rubin Observatory JIRA Cloud REST API to
-    update a jira ticket's specific field
+    update time_lost field in a given jira ticket
 
     Params
     ------
     jira_id: int
         Jira ID
+    add_time_lost: float
+        time value given from comment
 
     Returns
     -------
     Response
         The response and status code of the request to the JIRA API
+        200 if the time_lost field was successfully updated
+        400 if the time_lost field was not updated
     """
     headers = {
         "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",
         "content-type": "application/json",
     }
-    get_url = (
-        f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/issue/{jira_id}"
-    )
-    response = requests.get(get_url, headers=headers)
-    existent_time_loss = (
-        response.json().get("customfield_10106", 0.0)
+    url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/issue/{jira_id}/"
+    response = requests.get(url, headers=headers)
+    existent_time_lost = (
+        response.json().get(TIME_LOST_FIELD, 0.0)
         if response.status_code == 200
         else 0.0
     )
     jira_payload = {
         "fields": {
-            "customfield_10106": float(existent_time_loss + add_time_loss),
+            TIME_LOST_FIELD: float(existent_time_lost + add_time_lost),
         },
     }
-    put_url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/issue/{jira_id}/"
-    response = requests.put(put_url, json=jira_payload, headers=headers)
-
-    if response.status_code == 200 or response.status_code == 204:
+    response = requests.put(url, json=jira_payload, headers=headers)
+    if response.status_code == 204:
         return Response(
             {
-                "ack": "Jira field updated",
+                "ack": "Jira time_lost field updated",
                 "url": f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/{jira_id}",
             },
             status=200,
@@ -600,8 +603,8 @@ def jira_comment(request_data):
     response = requests.post(url, json=jira_payload, headers=headers)
 
     if "time_lost" in request_data:
-        response = update_time_loss(
-            jira_id=jira_id, add_time_loss=request_data.get("time_lost", 0.0)
+        response = update_time_lost(
+            jira_id=jira_id, add_time_lost=request_data.get("time_lost", 0.0)
         )
         if response.status_code == 400:
             return response
@@ -677,8 +680,8 @@ def get_jira_obs_report(request_data):
                 "key": issue["key"],
                 "summary": issue["fields"]["summary"],
                 "time_lost": (
-                    issue["fields"]["customfield_10106"]
-                    if issue["fields"]["customfield_10106"] is not None
+                    issue["fields"][TIME_LOST_FIELD]
+                    if issue["fields"][TIME_LOST_FIELD] is not None
                     else 0.0
                 ),
                 "reporter": issue["fields"]["creator"]["displayName"],

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -550,7 +550,7 @@ def update_time_loss(jira_id: int, add_time_loss: float = 0.0) -> Response:
         )
     return Response(
         {
-            "ack": "Jira field could not be updated",
+            "ack": "Jira time_lost field could not be updated",
         },
         status=400,
     )

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -605,7 +605,7 @@ def jira_comment(request_data):
         timelost_response = update_time_lost(
             jira_id=jira_id, add_time_lost=request_data.get("time_lost", 0.0)
         )
-        if timelost_response.status_code == 400:
+        if timelost_response.status_code != 200:
             return timelost_response
 
     if response.status_code == 201:

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -601,7 +601,6 @@ def jira_comment(request_data):
     }
     url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/issue/{jira_id}/comment"
     response = requests.post(url, json=jira_payload, headers=headers)
-
     if "time_lost" in request_data:
         timelost_response = update_time_lost(
             jira_id=jira_id, add_time_lost=request_data.get("time_lost", 0.0)


### PR DESCRIPTION
Added update_time_loss() to request jira ticket by ID, and updates the existing time_lost value adding what was given in the form to the original value from the ticket.
Called this function from jira_comment() only if 'time_lost' is provided in the request_data. 

Updated test_jira_comment() to patch this new function. 
Added test_update_time_loss.