### PR TITLE
Adjust websockets routing as prefix is not needed anymore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.0.1
+------
+
+* Adjust websockets routing as prefix is not needed anymore `<https://github.com/lsst-ts/LOVE-manager/pull/276>`_
+
 v7.0.0
 ------
 

--- a/manager/subscription/routing.py
+++ b/manager/subscription/routing.py
@@ -20,16 +20,13 @@
 
 """Define the rules for routing
 of channels messages (websockets) in the subscription application."""
-from django.conf import settings
 from django.urls import re_path
 
 from .consumers import SubscriptionConsumer
 
-URL_PREFIX = settings.FORCE_SCRIPT_NAME[1:] + "/" if settings.FORCE_SCRIPT_NAME else ""
-
 websocket_urlpatterns = [
     re_path(
-        rf"^{URL_PREFIX}manager(.*?)/ws/subscription/?$",
+        r"^manager(.*?)/ws/subscription/?$",
         SubscriptionConsumer.as_asgi(),
     ),
 ]


### PR DESCRIPTION
This PR fixes an issue with the websockets routing that was introduced after updating the LOVE-manager on #270. After updating the django dependency, we don't need anymore to force the prefix in base to the `FORCE_SCRIPT_NAME` setting. This is being added to the websocket path automatically now.