### PR TITLE
Fix issue with update_time_lost method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,15 @@
 Version History
 ===============
 
+v7.0.3
+------
+
+* Fix issue with update_time_lost method `<https://github.com/lsst-ts/LOVE-manager/pull/277>`_
+
 v7.0.2
 ------
 
-* Add accumulation of time lost in Jira comments
+* Add accumulation of time lost in Jira comments `<https://github.com/lsst-ts/LOVE-manager/pull/275>`_
 
 v7.0.1
 ------


### PR DESCRIPTION
This PR fixes an issue on the `update_time_lost` method by not properly reading the time lost field from the `fields` attribute that comes on the jira ticket query. Also the time_lost field passed as argument of the function comes in string format, so that needs to be parsed to `float` too so when adding time lost the code doesn't break.