### PR TITLE
Add identity to issued commands through the commander view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Version History
 ===============
 
-v7.0.4
+v7.1.0
 ------
 
+* Add identity to issued commands through the commander view `<https://github.com/lsst-ts/LOVE-manager/pull/278>`_
 * Remove cmd user creation for production deployments `<https://github.com/lsst-ts/LOVE-manager/pull/280>`_
 
 v7.0.3

--- a/manager/api/tests/test_commander.py
+++ b/manager/api/tests/test_commander.py
@@ -19,12 +19,14 @@
 
 
 import os
+from unittest.mock import call, patch
+
+from api.models import Token
+from django.contrib.auth.models import Permission, User
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from api.models import Token
 from rest_framework.test import APIClient
-from django.contrib.auth.models import User, Permission
-from unittest.mock import patch, call
+
 from manager.utils import UserBasedPermission
 
 # python manage.py test api.tests.test_commander.CommanderTestCase
@@ -60,6 +62,7 @@ class CommanderTestCase(TestCase):
         os.environ["COMMANDER_PORT"] = "bar"
 
     @patch("requests.post")
+    @patch.dict(os.environ, {"SERVER_URL": "localhost"})
     def test_authorized_commander_data(self, mock_requests):
         """Test authorized user commander data is sent to love-commander"""
         # Arrange:
@@ -73,11 +76,15 @@ class CommanderTestCase(TestCase):
             "cmd": "cmd_setScalars",
             "params": {"a": 1, "b": 2},
         }
+        data_with_identity = data.copy()
+        data_with_identity["identity"] = f"{self.user.username}@localhost"
 
         with self.assertRaises(ValueError):
             self.client.post(url, data, format="json")
         expected_url = "http://foo:bar/cmd"
-        self.assertEqual(mock_requests.call_args, call(expected_url, json=data))
+        self.assertEqual(
+            mock_requests.call_args, call(expected_url, json=data_with_identity)
+        )
 
     @patch("requests.post")
     def test_unauthorized_commander(self, mock_requests):

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -437,7 +437,9 @@ def validate_config_schema(request):
 @permission_classes((IsAuthenticated, CommandPermission))
 def commander(request):
     """Sends a command to the LOVE-commander
-    according to the received parameters
+    according to the received parameters.
+
+    Command identity is arranged here.
 
     Params
     ------
@@ -449,8 +451,13 @@ def commander(request):
     Response
         The response and status code of the request to the LOVE-Commander
     """
+    # Arrange command indentity
+    request_data = request.data.copy()
+    host_fqdn = os.environ.get("SERVER_URL", None)
+    request_data["identity"] = f"{request.user.username}@{host_fqdn}"
+
     url = f"http://{os.environ.get('COMMANDER_HOSTNAME')}:{os.environ.get('COMMANDER_PORT')}/cmd"
-    response = requests.post(url, json=request.data)
+    response = requests.post(url, json=request_data)
 
     return Response(response.json(), status=response.status_code)
 


### PR DESCRIPTION
This PR extends the `commander` view to arrange the identity of whom is issuing a command from the LOVE-frontend.
This is connected to a LOVE-commander PR too: https://github.com/lsst-ts/LOVE-commander/pull/74.