### PR TITLE
Remove cmd user creation for production deployments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.0.4
+------
+
+* Remove cmd user creation for production deployments `<https://github.com/lsst-ts/LOVE-manager/pull/280>`_
+
 v7.0.3
 ------
 

--- a/manager/api/management/commands/tests.py
+++ b/manager/api/management/commands/tests.py
@@ -51,7 +51,7 @@ class CreateusersTestCase(TestCase):
         command.handle(*[], **options)
         # Assert:
         self.assertEqual(
-            User.objects.count(), old_users_num + 4, "There are no new users"
+            User.objects.count(), old_users_num + 3, "There are no new users"
         )
         self.assertEqual(
             Group.objects.count(), old_groups_num + 2, "There is no new group"

--- a/manager/runserver.sh
+++ b/manager/runserver.sh
@@ -12,7 +12,7 @@ echo -e "\nApplying migrations"
 python manage.py migrate
 
 echo -e "\nCreating default users"
-python manage.py createusers --adminpass ${ADMIN_USER_PASS} --userpass ${USER_USER_PASS} --cmduserpass ${CMD_USER_PASS}
+python manage.py createusers --adminpass ${ADMIN_USER_PASS} --userpass ${USER_USER_PASS}
 if [ -z ${LOVE_SITE} ]; then
   love_site="summit"
 else


### PR DESCRIPTION
This PR extends the `createusers` command to include conditionals for user creation, so if a password is not defined when calling the command, the user won't be created. This way we can make the `runserver.sh` script to not include the `cmd` user pass, so this user is not created on the production deployments.