### PR TITLE
Fix issue with update_time_lost being called on jira tickets that doesn't have a time lost defined

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.1.1
+------
+
+* Fix issue with update_time_lost being called on jira tickets that doesn't have a time lost defined `<https://github.com/lsst-ts/LOVE-manager/pull/282>`_
+
 v7.1.0
 ------
 

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -353,6 +353,26 @@ class JiraTestCase(TestCase):
         assert jira_response.status_code == 400
         assert jira_response.data["ack"] == "Jira time_lost field could not be updated"
 
+    def test_update_current_time_lost_none(self):
+        """Test call to update_time_lost with None as current time_lost"""
+        mock_jira_patcher = patch("requests.get")
+        mock_jira_get = mock_jira_patcher.start()
+        response_get = requests.Response()
+        response_get.status_code = 200
+        response_get.json = lambda: {"fields": {TIME_LOST_FIELD: None}}
+        mock_jira_get.return_value = response_get
+
+        put_patcher = patch("requests.put")
+        mock_jira_put = put_patcher.start()
+        response_put = requests.Response()
+        response_put.status_code = 204
+        mock_jira_put.return_value = response_put
+
+        # call update time lost
+        jira_response = update_time_lost(1, 3.4)
+        assert jira_response.status_code == 200
+        assert jira_response.data["ack"] == "Jira time_lost field updated"
+
     def test_add_comment(self):
         """Test call to jira_comment function with all needed parameters"""
         mock_jira_patcher = patch("requests.post")

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -535,7 +535,8 @@ def update_time_lost(jira_id: int, add_time_lost: float = 0.0) -> Response:
 
     if response.status_code == 200:
         jira_ticket_fields = response.json().get("fields", {})
-        existent_time_lost = float(jira_ticket_fields.get(TIME_LOST_FIELD, 0.0))
+        time_lost_value = jira_ticket_fields.get(TIME_LOST_FIELD, 0.0)
+        existent_time_lost = float(time_lost_value) if time_lost_value else 0.0
         jira_payload = {
             "fields": {
                 TIME_LOST_FIELD: existent_time_lost + add_time_lost,


### PR DESCRIPTION
This PR includes updates to the `update_time_lost` functionality and adds a new test case to ensure proper handling when the `time_lost` field is `None` for jira tickets that have not set that field.

### Updates to `update_time_lost` functionality:

* [`manager/manager/utils.py`](diffhunk://#diff-5495c8c9a3db0b4bd6fdb5797165e55eb8f5fffd8d98911c57f65ff621f796c2L538-R539): Modified the `update_time_lost` function to handle cases where the `time_lost` field is `None` by checking the value before converting it to a float.

### New test case:

* [`manager/api/tests/test_jira.py`](diffhunk://#diff-251265ce41ecb04086672a260886e6b0b1a598a430d342b3654db5cb2db5b690R356-R375): Added a new test `test_update_current_time_lost_none` to verify that the `update_time_lost` function correctly updates the `time_lost` field when it is initially `None`.