### PR TITLE
Fix issue with django admin panel not accessible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.1
 ------
 
+* Fix issue with django admin panel not accessible `<https://github.com/lsst-ts/LOVE-manager/pull/283>`_
 * Add ESS:109 to the summit initial dataset. `<https://github.com/lsst-ts/LOVE-manager/pull/281>`_
 * Fix issue with update_time_lost being called on jira tickets that doesn't have a time lost defined `<https://github.com/lsst-ts/LOVE-manager/pull/282>`_
 

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -97,13 +97,18 @@ else:
         }
     }
 
+SERVER_URL = os.environ.get("SERVER_URL", None)
 ALLOWED_HOSTS = [
     "localhost",
     "0.0.0.0",
     "127.0.0.1",
     "love-nginx-mount",
     "love-nginx",
-    os.environ.get("SERVER_URL", None),
+    SERVER_URL,
+]
+CSRF_TRUSTED_ORIGINS = [
+    f"https://{SERVER_URL}",
+    f"http://{SERVER_URL}"
 ]
 """List of Django allowed hosts (`list` of `string`)"""
 


### PR DESCRIPTION
This PR adds the `CSRF_TRUSTED_ORIGINS` django setting which define hosts to allow cross site requests (requests that don't come from the same domain). This is a security measure that django sets, but it was generating some problems as the LOVE architecture forwards requests through nginx proxies which happens to set a different origin by using `http` instead of `https`. This made requests from the UI been detected as a different origin due to been generated from an `https` origin.

I've tried changing nginx proxies (e.g. https://github.com/lsst-ts/argocd-csc/blob/main/apps/love-nginx/values-tucson-teststand.yaml#L41-L73) but other services, such as the producers relies on non secure connection (`ws` instead of `wss`) so that generated problems.

This is solved by setting the `CSRF_TRUSTED_ORIGINS` to provide options for `http` and `https` on the current server url.