### PR TITLE
Fix date conversion for the get_jira_obs_report method

### DIFF
--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -656,8 +656,11 @@ def get_jira_obs_report(request_data):
     Then get the total observation time loss from the time_lost param
     """
 
-    initial_day_obs_string = get_obsday_iso(request_data.get("day_obs"))
-    final_day_obs_string = get_obsday_iso(request_data.get("day_obs") + 1)
+    intitial_day_obs_tai = get_obsday_to_tai(request_data.get("day_obs"))
+    final_day_obs_tai = intitial_day_obs_tai + timedelta(days=1)
+
+    initial_day_obs_string = intitial_day_obs_tai.strftime("%Y-%m-%d")
+    final_day_obs_string = final_day_obs_tai.strftime("%Y-%m-%d")
 
     # JQL query to find issues created on a specific date
     jql_query = (
@@ -731,6 +734,25 @@ def get_obsday_from_tai(tai):
     if tai.hour < 12:
         observing_day = (tai - timedelta(days=1)).strftime("%Y%m%d")
     return observing_day
+
+
+def get_obsday_to_tai(obsday):
+    """Return the TAI timestamp from an observing day.
+
+    The TAI timestamp is set to 12:00 UTC of the observing day.
+
+    Parameters
+    ----------
+    obsday : `int`
+        The observing day in the format "YYYYMMDD" as an integer
+
+    Returns
+    -------
+    `datetime.datetime`
+        The TAI timestamp
+    """
+    obsday_iso = get_obsday_iso(obsday)
+    return Time(f"{obsday_iso}T12:00:00", scale="tai").datetime
 
 
 def get_obsday_iso(obsday):


### PR DESCRIPTION
This PR fix the date conversion being made on the `get_jira_obs_report` method. This is being used by the `ole_send_night_report` view which arranges the email that is sent at the end of the night as a night log. We realized this was failing the date of the 30th of September and it was because the query to the Jira REST API was setting the `from` & `to` dates as `current_obsday` & `current_obsday+1`. As the obsday was being passed to the `get_jira_obs_report` as an integer, the query for the 30th of September was trying to set `20240930` to `20240931` whereas this last date doesn't exist, making the Jira request to fail.