### PR TITLE
Add MTM1M3TS to ASummaryState view fixture on Summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.4
 ------
 
+* Add MTM1M3TS to ASummaryState view fixture on Summit. `<https://github.com/lsst-ts/LOVE-manager/pull/289>`_
 * Standardize SummaryState view on TTS and BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/288>`_
 
 v7.1.3

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -883,6 +883,10 @@
                       "salindex": 0
                     },
                     {
+                      "name": "MTM1M3TS",
+                      "salindex": 0
+                    },
+                    {
                       "name": "MTM2",
                       "salindex": 0
                     },


### PR DESCRIPTION
This PR adds the `MTM1M3TS` CSC to the `ASummaryState` view fixture on Summit.