### PR TITLE
Add LedProjector and LinearStage CSCs to ASummaryState view fixture on Summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.1.5
+------
+
+* Add LedProjector and LinearStage CSCs to ASummaryState view fixture on Summit. `<https://github.com/lsst-ts/LOVE-manager/pull/291>`_
+
 v7.1.4
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1069,14 +1069,6 @@
                     {
                       "name": "Electrometer",
                       "salindex": 201
-                    },
-                    {
-                      "name": "LinearStage",
-                      "salindex": 1
-                    },
-                    {
-                      "name": "LinearStage",
-                      "salindex": 2
                     }
                   ]
                 }

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -995,6 +995,26 @@
                     {
                       "name": "TunableLaser",
                       "salindex": 0
+                    },
+                    {
+                      "name": "LEDProjector",
+                      "salindex": 0
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 101
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 102
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 103
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 104
                     }
                   ]
                 },


### PR DESCRIPTION
This PR adds the following CSCs to the ASummary State view fixture on Summit:

- LedProjector:0
- LinearStage:101
- LinearStage:102
- LinearStage:103
- LinearStage:104

These are being added under the `Simonyi Survey Telescope` > `Calibration Systems` section.