### PR TITLE
Refactor get_jira_obs_report method to account for JIRA REST API user timezone.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.1.6
+------
+
+* Refactor get_jira_obs_report method to account for JIRA REST API user timezone. `<https://github.com/lsst-ts/LOVE-manager/pull/292>`_
+
 v7.1.5
 ------
 


### PR DESCRIPTION
This PR refactors the `get_jira_obs_report` method to account for timezones when using the JIRA REST API so we don't rely on a hardcoded date range for queries which could affect if using different users to authenticate the query and also account for daylight saving time. Tests were extended to comply with these changes.