### PR TITLE
Make the SummaryState view as the official one for TTS and BTS.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.6
 ------
 
+* Make the SummaryState view as the official one for TTS and BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/293>`_
 * Refactor get_jira_obs_report method to account for JIRA REST API user timezone. `<https://github.com/lsst-ts/LOVE-manager/pull/292>`_
 
 v7.1.5

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -477,7 +477,7 @@
     "fields": {
       "creation_timestamp": "2021-02-11T07:26:03.945541Z",
       "update_timestamp": "2022-04-13T21:22:24.863664Z",
-      "name": "SummaryState3",
+      "name": "SummaryState",
       "data": {
         "content": {
           "newPanel-1": {

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -494,6 +494,10 @@
                       "salindex": 0
                     },
                     {
+                      "name": "DREAM",
+                      "salindex": 0
+                    },
+                    {
                       "name": "DIMM",
                       "salindex": 1
                     },
@@ -512,6 +516,10 @@
                     {
                       "name": "EPM",
                       "salindex": 1
+                    },
+                    {
+                      "name": "EAS",
+                      "salindex": 0
                     },
                     {
                       "name": "ESS",
@@ -612,6 +620,10 @@
                       "salindex": 2
                     },
                     {
+                      "name": "OCPS",
+                      "salindex": 101
+                    },
+                    {
                       "name": "Watcher",
                       "salindex": 0
                     }
@@ -707,6 +719,40 @@
                       "name": "CCHeaderService",
                       "salindex": 0
                     }
+                  ],
+                  "Calibration Systems": [
+                    {
+                      "name": "CBP",
+                      "salindex": 0
+                    },
+                    {
+                      "name": "LEDProjector",
+                      "salindex": 0
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 101
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 102
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 103
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 104
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 101
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 102
+                    }
                   ]
                 }
               },
@@ -777,6 +823,18 @@
                       "name": "ATSpectrograph",
                       "salindex": 0
                     }
+                  ],
+                  "Calibration Systems": [
+                    {
+                      "name": "Electrometer",
+                      "salindex": 201
+                    }
+                  ],
+                  "Support & Monitoring": [
+                    {
+                      "name": "ATBuilding",
+                      "salindex": 0
+                    }
                   ]
                 }
               },
@@ -784,7 +842,7 @@
             },
             "content": "CSCSummary",
             "properties": {
-              "h": 28,
+              "h": 35,
               "i": 3,
               "w": 31,
               "x": 66,

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -477,7 +477,7 @@
     "fields": {
       "creation_timestamp": "2021-02-11T07:26:03.945541Z",
       "update_timestamp": "2022-04-13T21:22:24.863664Z",
-      "name": "SummaryState2",
+      "name": "SummaryState",
       "data": {
         "content": {
           "newPanel-1": {


### PR DESCRIPTION
This PR renames the Summary State views on TTS and BTS to `SummaryState`. Also recently added CSCs to TTS were included on this view. The following CSCs were added to the TTS `SummaryState` view: `DREAM`, `EAS`, `OCPS:101`, `CBP`, `LEDProjector`, `LinearStage[101,202,103,104]`, `Electrometer[101,102,201]` and `ATBuilding`.
