### PR TITLE
Show error details from queries to the JIRA REST API.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.6
 ------
 
+* Show error details from queries to the JIRA REST API. `<https://github.com/lsst-ts/LOVE-manager/pull/294>`_
 * Make the SummaryState view as the official one for TTS and BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/293>`_
 * Refactor get_jira_obs_report method to account for JIRA REST API user timezone. `<https://github.com/lsst-ts/LOVE-manager/pull/292>`_
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -503,7 +503,11 @@ def jira_ticket(request_data):
     return Response(
         {
             "ack": "Jira ticket could not be created",
-            "error": response_data,
+            "error": (
+                str(response_data["errors"])
+                if "errors" in response_data
+                else str(response_data)
+            ),
         },
         status=400,
     )


### PR DESCRIPTION
This PR extends the `jira_ticket` utility function to send errors details that comes from querying the JIRA REST API.
This PR is related to: https://github.com/lsst-ts/LOVE-frontend/pull/678.