### PR TITLE
Add EAS:0 CSC to summit ASummary State view on Summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.6
 ------
 
+* Add EAS:0 CSC to summit ASummary State view on Summit. `<https://github.com/lsst-ts/LOVE-manager/pull/295>`_
 * Show error details from queries to the JIRA REST API. `<https://github.com/lsst-ts/LOVE-manager/pull/294>`_
 * Make the SummaryState view as the official one for TTS and BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/293>`_
 * Refactor get_jira_obs_report method to account for JIRA REST API user timezone. `<https://github.com/lsst-ts/LOVE-manager/pull/292>`_

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -749,6 +749,10 @@
                       "salindex": 301
                     },
                     {
+                      "name": "EAS",
+                      "salindex": 0
+                    },
+                    {
                       "name": "ESS",
                       "salindex": 1
                     },


### PR DESCRIPTION
This PR adds the new `EAS:0` CSC to the `ASummary State` view on Summit.