### PR TITLE
Make channels layer group expiry parameter configurable through an environment variable.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.1.7
+------
+
+* Make channels layer group expiry parameter configurable through an environment variable. `<https://github.com/lsst-ts/LOVE-manager/pull/296>`_
+
 v7.1.6
 ------
 

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -106,10 +106,7 @@ ALLOWED_HOSTS = [
     "love-nginx",
     SERVER_URL,
 ]
-CSRF_TRUSTED_ORIGINS = [
-    f"https://{SERVER_URL}",
-    f"http://{SERVER_URL}"
-]
+CSRF_TRUSTED_ORIGINS = [f"https://{SERVER_URL}", f"http://{SERVER_URL}"]
 """List of Django allowed hosts (`list` of `string`)"""
 
 # Application definition
@@ -254,6 +251,7 @@ REDIS_PORT = os.environ.get("REDIS_PORT", "6379")
 REDIS_PASS = os.environ.get("REDIS_PASS", False)
 REDIS_CONFIG_EXPIRY = int(os.environ.get("REDIS_CONFIG_EXPIRY", 60))
 REDIS_CONFIG_CAPACITY = int(os.environ.get("REDIS_CONFIG_CAPACITY", 100))
+REDIS_CONFIG_GROUP_EXPIRY = int(os.environ.get("REDIS_CONFIG_GROUP_EXPIRY", 43200))
 if REDIS_HOST and not TESTING:
     CHANNEL_LAYERS = {
         "default": {
@@ -270,11 +268,7 @@ if REDIS_HOST and not TESTING:
                 ],
                 "expiry": REDIS_CONFIG_EXPIRY,
                 "capacity": REDIS_CONFIG_CAPACITY,
-                # Set group_expiry to 1 year to avoid group messages being
-                # dropped when the group is not used frequently.
-                # TODO: Solve this particular issue in a better way.
-                # See: DM-41728
-                "group_expiry": 31536000,
+                "group_expiry": REDIS_CONFIG_GROUP_EXPIRY,
             },
         },
     }


### PR DESCRIPTION
This PR adjusts the django settings to be able to configure the channels `group_expiry` through an environment variable.