### PR TITLE
Add recently added CSCs to SummaryState view on BTS.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.7
 ------
 
+* Add recently added CSCs to SummaryState view on BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/297>`_
 * Make channels layer group expiry parameter configurable through an environment variable. `<https://github.com/lsst-ts/LOVE-manager/pull/296>`_
 
 v7.1.6

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -494,6 +494,10 @@
                       "salindex": 0
                     },
                     {
+                      "name": "DREAM",
+                      "salindex": 0
+                    },
+                    {
                       "name": "DIMM",
                       "salindex": 1
                     },
@@ -512,6 +516,10 @@
                     {
                       "name": "EPM",
                       "salindex": 1
+                    },
+                    {
+                      "name": "EAS",
+                      "salindex": 0
                     },
                     {
                       "name": "ESS",
@@ -612,6 +620,10 @@
                       "salindex": 3
                     },
                     {
+                      "name": "OCPS",
+                      "salindex": 101
+                    },
+                    {
                       "name": "Watcher",
                       "salindex": 0
                     }
@@ -622,7 +634,7 @@
             },
             "content": "CSCSummary",
             "properties": {
-              "h": 47,
+              "h": 61,
               "i": 1,
               "w": 33,
               "x": 0,
@@ -680,20 +692,6 @@
                       "salindex": 0
                     }
                   ],
-                  "Support & Monitoring": [
-                    {
-                      "name": "MTAirCompressor",
-                      "salindex": 1
-                    },
-                    {
-                      "name": "MTAirCompressor",
-                      "salindex": 2
-                    },
-                    {
-                      "name": "LaserTracker",
-                      "salindex": 1
-                    }
-                  ],
                   "LSSTCam": [
                     {
                       "name": "MTCamera",
@@ -707,6 +705,58 @@
                       "name": "MTHeaderService",
                       "salindex": 0
                     }
+                  ],
+                  "Calibration Systems": [
+                    {
+                      "name": "CBP",
+                      "salindex": 0
+                    },
+                    {
+                      "name": "LEDProjector",
+                      "salindex": 0
+                    },
+                    {
+                      "name": "TunableLaser",
+                      "salindex": 0
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 101
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 102
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 103
+                    },
+                    {
+                      "name": "LinearStage",
+                      "salindex": 104
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 101
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 102
+                    }
+                  ],
+                  "Support & Monitoring": [
+                    {
+                      "name": "MTAirCompressor",
+                      "salindex": 1
+                    },
+                    {
+                      "name": "MTAirCompressor",
+                      "salindex": 2
+                    },
+                    {
+                      "name": "LaserTracker",
+                      "salindex": 1
+                    }
                   ]
                 }
               },
@@ -714,7 +764,7 @@
             },
             "content": "CSCSummary",
             "properties": {
-              "h": 40,
+              "h": 61,
               "i": 2,
               "w": 33,
               "x": 33,
@@ -777,6 +827,18 @@
                       "name": "ATSpectrograph",
                       "salindex": 0
                     }
+                  ],
+                  "Calibration Systems": [
+                    {
+                      "name": "Electrometer",
+                      "salindex": 201
+                    }
+                  ],
+                  "Support & Monitoring": [
+                    {
+                      "name": "ATBuilding",
+                      "salindex": 0
+                    }
                   ]
                 }
               },
@@ -784,9 +846,9 @@
             },
             "content": "CSCSummary",
             "properties": {
-              "h": 28,
+              "h": 45,
               "i": 3,
-              "w": 31,
+              "w": 32,
               "x": 66,
               "y": 0,
               "type": "component"
@@ -816,11 +878,11 @@
             },
             "content": "CSCSummary",
             "properties": {
-              "h": 12,
+              "h": 16,
               "i": 4,
-              "w": 31,
+              "w": 32,
               "x": 66,
-              "y": 28,
+              "y": 45,
               "type": "component"
             }
           }


### PR DESCRIPTION
This PR adds the following list of CSCs to the SummaryState view on BTS:

- ATBuilding
- DREAM
- EAS
- LEDProjector
- LinearStage:[101,102,103,104]
- CBP, Electrometer:[101,102,201]
- OCPS:101