### PR TITLE
Convert narrativelog date_begin and date_end UTC datetimes to TAI.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.1.7
 ------
 
+* Convert narrativelog date_begin and date_end UTC datetimes to TAI. `<https://github.com/lsst-ts/LOVE-manager/pull/299>`_
 * Add recently added CSCs to SummaryState view on BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/297>`_
 * Make channels layer group expiry parameter configurable through an environment variable. `<https://github.com/lsst-ts/LOVE-manager/pull/296>`_
 

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -139,6 +139,8 @@ class OLETestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
+        mock_ole_client.stop()
+
     def test_simple_exposurelog_create(self):
         """Test exposurelog create."""
         # Arrange:
@@ -158,6 +160,8 @@ class OLETestCase(TestCase):
         response = self.client.post(url, self.payload_full_exposure)
         self.assertEqual(response.status_code, 201)
 
+        mock_ole_client.stop()
+
     def test_exposurelog_update(self):
         """Test exposurelog update."""
         # Arrange:
@@ -176,6 +180,8 @@ class OLETestCase(TestCase):
         url = reverse("ExposureLogs-detail", args=[1])
         response = self.client.put(url, self.payload_full_exposure)
         self.assertEqual(response.status_code, 200)
+
+        mock_ole_client.stop()
 
     def test_exposurelog_create_with_jira(self):
         """Test exposurelog create with jira."""
@@ -222,6 +228,9 @@ class OLETestCase(TestCase):
         response = self.client.post(url, self.payload_full_exposure_with_jira_comment)
         self.assertEqual(response.status_code, 201)
 
+        mock_jira_ticket_client.stop()
+        mock_ole_client.stop()
+
     def test_exposurelog_update_with_jira(self):
         """Test exposurelog update with jira."""
         # Arrange:
@@ -267,6 +276,9 @@ class OLETestCase(TestCase):
         response = self.client.put(url, self.payload_full_exposure_with_jira_comment)
         self.assertEqual(response.status_code, 200)
 
+        mock_jira_ticket_client.stop()
+        mock_ole_client.stop()
+
     def test_narrativelog_list(self):
         """Test narrativelog list."""
         # Arrange:
@@ -287,6 +299,8 @@ class OLETestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
+        mock_ole_client.stop()
+
     def test_simple_narrativelog_create(self):
         """Test narrativelog create."""
         # Arrange:
@@ -306,6 +320,8 @@ class OLETestCase(TestCase):
         response = self.client.post(url, self.payload_full_narrative)
         self.assertEqual(response.status_code, 201)
 
+        mock_ole_client.stop()
+
     def test_narrativelog_update(self):
         """Test narrativelog update."""
         # Arrange:
@@ -324,6 +340,8 @@ class OLETestCase(TestCase):
         url = reverse("NarrativeLogs-detail", args=[1])
         response = self.client.put(url, self.payload_full_narrative)
         self.assertEqual(response.status_code, 200)
+
+        mock_ole_client.stop()
 
     def test_narrative_log_create_with_jira(self):
         """Test narrativelog create with jira."""
@@ -370,6 +388,9 @@ class OLETestCase(TestCase):
         response = self.client.post(url, self.payload_full_narrative_with_jira_comment)
         self.assertEqual(response.status_code, 201)
 
+        mock_jira_ticket_client.stop()
+        mock_ole_client.stop()
+
     def test_narrative_log_update_with_jira(self):
         """Test narrativelog update with jira."""
         # Arrange:
@@ -414,6 +435,9 @@ class OLETestCase(TestCase):
         url = reverse("NarrativeLogs-detail", args=[1])
         response = self.client.put(url, self.payload_full_narrative_with_jira_comment)
         self.assertEqual(response.status_code, 200)
+
+        mock_jira_ticket_client.stop()
+        mock_ole_client.stop()
 
 
 @override_settings(DEBUG=True)
@@ -485,6 +509,8 @@ class NightReportTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
+        mock_ole_client.stop()
+
     def test_simple_nightreport_create(self):
         """Test nightreport create."""
         # Arrange:
@@ -503,6 +529,8 @@ class NightReportTestCase(TestCase):
         url = reverse("NightReportLogs-list")
         response = self.client.post(url, self.payload)
         self.assertEqual(response.status_code, 201)
+
+        mock_ole_client.stop()
 
     def test_nightreport_update(self):
         """Test nightreport update."""
@@ -523,6 +551,8 @@ class NightReportTestCase(TestCase):
         response = self.client.put(url, self.payload)
         self.assertEqual(response.status_code, 200)
 
+        mock_ole_client.stop()
+
     def test_nightreport_delete(self):
         """Test nightreport delete."""
         # Arrange:
@@ -541,6 +571,8 @@ class NightReportTestCase(TestCase):
         url = reverse("NightReportLogs-detail", args=[1])
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 200)
+
+        mock_ole_client.stop()
 
     def test_nightreport_send(self):
         """Test nightreport send."""
@@ -578,6 +610,11 @@ class NightReportTestCase(TestCase):
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
 
+        mock_ole_client_get.stop()
+        mock_ole_client_patch.stop()
+        mock_get_jira_obs_report_client.stop()
+        mock_send_smtp_email_client.stop()
+
     def test_nightreport_already_sent(self):
         """Test nightreport already sent."""
         # Arrange:
@@ -601,3 +638,5 @@ class NightReportTestCase(TestCase):
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, {"error": "Night report already sent"})
+
+        mock_ole_client_get.stop()

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -71,8 +71,8 @@ class OLETestCase(TestCase):
             "components": "MainTel",
             "primary_software_components": "None",
             "primary_hardware_components": "None",
-            "date_begin": "202200703-19:58:13",
-            "date_end": "20220704-19:25:13",
+            "date_begin": "2020-07-03T19:58:13.000000",
+            "date_end": "2022-07-04T19:25:13.000000",
             "time_lost": 10,
             "level": 0,
         }

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -70,6 +70,7 @@ from manager.utils import (
     get_jira_obs_report,
     get_obsday_from_tai,
     get_obsday_iso,
+    get_tai_from_utc,
     handle_jira_payload,
     send_smtp_email,
     upload_to_lfa,
@@ -1307,6 +1308,16 @@ class NarrativelogViewSet(viewsets.ViewSet):
         if "file[]" in json_data:
             del json_data["file[]"]
 
+        # Convert date_begin and date_end to TAI format
+        date_keys = {
+            "date_begin",
+            "date_end",
+        }
+        for key in date_keys:
+            if key in json_data:
+                tai_datetime = get_tai_from_utc(json_data[key])
+                json_data[key] = tai_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
         # Split lists of values separated by comma
         array_keys = {
             "components",
@@ -1364,6 +1375,16 @@ class NarrativelogViewSet(viewsets.ViewSet):
 
         if "file[]" in json_data:
             del json_data["file[]"]
+
+        # Convert date_begin and date_end to TAI format
+        date_keys = {
+            "date_begin",
+            "date_end",
+        }
+        for key in date_keys:
+            if key in json_data:
+                tai_datetime = get_tai_from_utc(json_data[key])
+                json_data[key] = tai_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
         array_keys = {
             "components",

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -65,6 +65,7 @@ from manager.settings import (
     AUTH_LDAP_3_SERVER_URI,
 )
 from manager.utils import (
+    DATETIME_ISO_FORMAT,
     CommandPermission,
     arrange_nightreport_email,
     get_jira_obs_report,
@@ -1316,7 +1317,7 @@ class NarrativelogViewSet(viewsets.ViewSet):
         for key in date_keys:
             if key in json_data:
                 tai_datetime = get_tai_from_utc(json_data[key])
-                json_data[key] = tai_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")
+                json_data[key] = tai_datetime.strftime(DATETIME_ISO_FORMAT)
 
         # Split lists of values separated by comma
         array_keys = {
@@ -1384,7 +1385,7 @@ class NarrativelogViewSet(viewsets.ViewSet):
         for key in date_keys:
             if key in json_data:
                 tai_datetime = get_tai_from_utc(json_data[key])
-                json_data[key] = tai_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")
+                json_data[key] = tai_datetime.strftime(DATETIME_ISO_FORMAT)
 
         array_keys = {
             "components",

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -833,6 +833,22 @@ def get_tai_to_utc() -> float:
     return dt
 
 
+def get_tai_from_utc(utc):
+    """Return the TAI timestamp from an UTC timestamp.
+
+    Parameters
+    ----------
+    utc : `datetime.datetime`
+        UTC timestamp
+
+    Returns
+    -------
+    `datetime.datetime`
+        The TAI timestamp
+    """
+    return Time(utc, scale="utc").tai.datetime
+
+
 def get_times():
     """Return relevant time measures.
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -45,6 +45,8 @@ TIME_LOST_FIELD = "customfield_10106"
 PRIMARY_SOFTWARE_COMPONENTS_IDS = "customfield_10107"
 PRIMARY_HARDWARE_COMPONENTS_IDS = "customfield_10196"
 
+DATETIME_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
 
 class LocationPermission(BasePermission):
     """Permission class to check if the user is in the location whitelist."""


### PR DESCRIPTION
This PR adds a conversion for dates that comes in UTC scale and need to be converted to TAI to comply with the narrativelog REST API definitions. This PR is related to: https://github.com/lsst-ts/LOVE-frontend/pull/681.