### PR TITLE
Refactor jira_ticket method to comply with new OBS systems hierarchy.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.2.0
+------
+
+* Refactor jira_ticket method to comply with new OBS systems hierarchy. `<https://github.com/lsst-ts/LOVE-manager/pull/300>`_
+
 v7.1.7
 ------
 

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -30,7 +30,7 @@ import rest_framework
 from django.test import TestCase, override_settings
 
 from manager.utils import (
-    TIME_LOST_FIELD,
+    OBS_TIME_LOST_FIELD,
     get_jira_obs_report,
     handle_jira_payload,
     jira_comment,
@@ -332,7 +332,7 @@ class JiraTestCase(TestCase):
         mock_jira_get = mock_jira_patcher.start()
         response_get = requests.Response()
         response_get.status_code = 200
-        response_get.json = lambda: {"fields": {TIME_LOST_FIELD: 13.6}}
+        response_get.json = lambda: {"fields": {OBS_TIME_LOST_FIELD: 13.6}}
         mock_jira_get.return_value = response_get
 
         put_patcher = patch("requests.put")
@@ -366,7 +366,7 @@ class JiraTestCase(TestCase):
         mock_jira_get = mock_jira_patcher.start()
         response_get = requests.Response()
         response_get.status_code = 200
-        response_get.json = lambda: {"fields": {TIME_LOST_FIELD: None}}
+        response_get.json = lambda: {"fields": {OBS_TIME_LOST_FIELD: None}}
         mock_jira_get.return_value = response_get
 
         put_patcher = patch("requests.put")
@@ -534,7 +534,7 @@ class JiraTestCase(TestCase):
                     "key": "LOVE-XX",
                     "fields": {
                         "summary": "Issue title",
-                        TIME_LOST_FIELD: 13.6,
+                        OBS_TIME_LOST_FIELD: 13.6,
                         "creator": {"displayName": "user"},
                         "created": "2024-11-27T12:00:00.00000",
                     },

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1329,6 +1329,10 @@ class NarrativelogViewSet(viewsets.ViewSet):
             if key in json_data:
                 json_data[key] = json_data[key].split(",")
 
+        # Transform components_json to a dict
+        if "components_json" in json_data:
+            json_data["components_json"] = json.loads(json_data["components_json"])
+
         # Add LFA and JIRA urls to the payload
         json_data["urls"] = [jira_url, *lfa_urls]
         json_data["urls"] = list(filter(None, json_data["urls"]))
@@ -1396,6 +1400,10 @@ class NarrativelogViewSet(viewsets.ViewSet):
         for key in array_keys:
             if key in json_data:
                 json_data[key] = json_data[key].split(",")
+
+        # Transform components_json to a dict
+        if "components_json" in json_data:
+            json_data["components_json"] = json.loads(json_data["components_json"])
 
         # Add LFA and JIRA urls urls to the payload
         json_data["urls"] = [

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1319,16 +1319,6 @@ class NarrativelogViewSet(viewsets.ViewSet):
                 tai_datetime = get_tai_from_utc(json_data[key])
                 json_data[key] = tai_datetime.strftime(DATETIME_ISO_FORMAT)
 
-        # Split lists of values separated by comma
-        array_keys = {
-            "components",
-            "primary_software_components",
-            "primary_hardware_components",
-        }
-        for key in array_keys:
-            if key in json_data:
-                json_data[key] = json_data[key].split(",")
-
         # Transform components_json to a dict
         if "components_json" in json_data:
             json_data["components_json"] = json.loads(json_data["components_json"])
@@ -1391,10 +1381,8 @@ class NarrativelogViewSet(viewsets.ViewSet):
                 tai_datetime = get_tai_from_utc(json_data[key])
                 json_data[key] = tai_datetime.strftime(DATETIME_ISO_FORMAT)
 
+        # Split lists of values separated by comma
         array_keys = {
-            "components",
-            "primary_software_components",
-            "primary_hardware_components",
             "urls",
         }
         for key in array_keys:

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -46,11 +46,6 @@ OBS_ISSUE_TYPE_ID = "10065"
 OBS_TIME_LOST_FIELD = "customfield_10106"
 OBS_SYSTEMS_FIELD = "customfield_10476"
 
-# Using Unknown component for now
-# For a full list check:
-# https://rubinobs.atlassian.net/rest/api/latest/project/OBS/components
-OBS_DEFAULT_COMPONENT_ID = "11614"
-
 DATETIME_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
 
@@ -422,11 +417,7 @@ def jira_ticket(request_data):
 
     tags_data = request_data.get("tags").split(",") if request_data.get("tags") else []
 
-    obs_system_selection = (
-        request_data.get("jira_obs_selection")
-        if request_data.get("jira_obs_selection")
-        else '{"selection": []}'
-    )
+    obs_system_selection = request_data.get("jira_obs_selection")
 
     try:
         jira_payload = {
@@ -452,10 +443,10 @@ def jira_ticket(request_data):
                 #     else "off"
                 # ),
                 OBS_TIME_LOST_FIELD: float(request_data.get("time_lost", 0)),
-                OBS_SYSTEMS_FIELD: json.loads(obs_system_selection),
             },
-            "update": {"components": [{"set": [{"id": OBS_DEFAULT_COMPONENT_ID}]}]},
         }
+        if obs_system_selection:
+            jira_payload["fields"][OBS_SYSTEMS_FIELD] = json.loads(obs_system_selection)
     except Exception as e:
         return Response(
             {

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -41,9 +41,15 @@ from rest_framework.response import Response
 # Constants
 JSON_RESPONSE_LOCAL_STORAGE_NOT_ALLOWED = {"error": "Local storage not allowed."}
 JSON_RESPONSE_ERROR_NOT_VALID_JSON = {"error": "Not a valid JSON response."}
-TIME_LOST_FIELD = "customfield_10106"
-PRIMARY_SOFTWARE_COMPONENTS_IDS = "customfield_10107"
-PRIMARY_HARDWARE_COMPONENTS_IDS = "customfield_10196"
+
+OBS_ISSUE_TYPE_ID = "10065"
+OBS_TIME_LOST_FIELD = "customfield_10106"
+OBS_SYSTEMS_FIELD = "customfield_10476"
+
+# Using Unknown component for now
+# For a full list check:
+# https://rubinobs.atlassian.net/rest/api/latest/project/OBS/components
+OBS_DEFAULT_COMPONENT_ID = "11614"
 
 DATETIME_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
@@ -416,26 +422,16 @@ def jira_ticket(request_data):
 
     tags_data = request_data.get("tags").split(",") if request_data.get("tags") else []
 
-    components_ids = (
-        request_data.get("components_ids").split(",")
-        if request_data.get("components_ids")
-        else []
-    )
-    primary_software_components_ids = (
-        request_data.get("primary_software_components_ids").split(",")
-        if request_data.get("primary_software_components_ids")
-        else None
-    )
-    primary_hardware_components_ids = (
-        request_data.get("primary_hardware_components_ids").split(",")
-        if request_data.get("primary_hardware_components_ids")
-        else None
+    obs_system_selection = (
+        request_data.get("jira_obs_selection")
+        if request_data.get("jira_obs_selection")
+        else '{"selection": []}'
     )
 
     try:
         jira_payload = {
             "fields": {
-                "issuetype": {"id": "10065"},
+                "issuetype": {"id": OBS_ISSUE_TYPE_ID},
                 # If the JIRA_PROJECT_ID environment variable is not set,
                 # the project id is set to the OBS project by default: 10063.
                 # Set it in case the OBS project id has changed for any reason
@@ -455,26 +451,10 @@ def jira_ticket(request_data):
                 #     "on" if int(request_data.get("level", 0)) >= 100
                 #     else "off"
                 # ),
-                TIME_LOST_FIELD: float(request_data.get("time_lost", 0)),
-                # Default values of the following fields are set to -1
-                PRIMARY_SOFTWARE_COMPONENTS_IDS: {
-                    "id": (
-                        str(primary_software_components_ids[0])
-                        if primary_software_components_ids
-                        else "-1"
-                    )
-                },
-                PRIMARY_HARDWARE_COMPONENTS_IDS: {
-                    "id": (
-                        str(primary_hardware_components_ids[0])
-                        if primary_hardware_components_ids
-                        else "-1"
-                    )
-                },
+                OBS_TIME_LOST_FIELD: float(request_data.get("time_lost", 0)),
+                OBS_SYSTEMS_FIELD: json.loads(obs_system_selection),
             },
-            "update": {
-                "components": [{"set": [{"id": str(id)} for id in components_ids]}]
-            },
+            "update": {"components": [{"set": [{"id": OBS_DEFAULT_COMPONENT_ID}]}]},
         }
     except Exception as e:
         return Response(
@@ -490,7 +470,6 @@ def jira_ticket(request_data):
         "content-type": "application/json",
     }
     url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/issue/"
-
     response = requests.post(url, json=jira_payload, headers=headers)
     response_data = response.json()
     if response.status_code == 201:
@@ -542,11 +521,11 @@ def update_time_lost(jira_id: int, add_time_lost: float = 0.0) -> Response:
 
     if response.status_code == 200:
         jira_ticket_fields = response.json().get("fields", {})
-        time_lost_value = jira_ticket_fields.get(TIME_LOST_FIELD, 0.0)
+        time_lost_value = jira_ticket_fields.get(OBS_TIME_LOST_FIELD, 0.0)
         existent_time_lost = float(time_lost_value) if time_lost_value else 0.0
         jira_payload = {
             "fields": {
-                TIME_LOST_FIELD: existent_time_lost + add_time_lost,
+                OBS_TIME_LOST_FIELD: existent_time_lost + add_time_lost,
             },
         }
         response = requests.put(url, json=jira_payload, headers=headers)
@@ -734,8 +713,8 @@ def get_jira_obs_report(request_data):
                 "key": issue["key"],
                 "summary": issue["fields"]["summary"],
                 "time_lost": (
-                    issue["fields"][TIME_LOST_FIELD]
-                    if issue["fields"][TIME_LOST_FIELD] is not None
+                    issue["fields"][OBS_TIME_LOST_FIELD]
+                    if issue["fields"][OBS_TIME_LOST_FIELD] is not None
                     else 0.0
                 ),
                 "reporter": issue["fields"]["creator"]["displayName"],


### PR DESCRIPTION
This PR refactors the jira_ticket method to comply with the new OBS systems hierarchy:
- Adjusted the narrativelog view to parse the new `components_json` field which comes in json format.
- Remove the components setting for creating jira tickets.
- Refactored tests to comply with the new hierarchy.