### PR TITLE
Add new CSCs to the ASummary State view on summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.2.3
 ------
 
+* Add new CSCs to the ASummary State view on summit. `<https://github.com/lsst-ts/LOVE-manager/pull/311>`_
 * Bump django from 5.0.11 to 5.0.13 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/312>`_
 * Bump jinja2 from 3.1.5 to 3.1.6 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/310>`_
 * Updates for the ASummary State view on Summit. `<https://github.com/lsst-ts/LOVE-manager/pull/309>`_

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -997,12 +997,24 @@
                       "salindex": 0
                     },
                     {
+                      "name": "FiberSpectrograph",
+                      "salindex": 101
+                    },
+                    {
+                      "name": "FiberSpectrograph",
+                      "salindex": 102
+                    },
+                    {
                       "name": "Electrometer",
                       "salindex": 101
                     },
                     {
                       "name": "Electrometer",
                       "salindex": 102
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 103
                     },
                     {
                       "name": "TunableLaser",


### PR DESCRIPTION
This PR updates the `ASummary State` view on the `ui-framework` fixtures for summit. New CSCs were added to the `Simonyi Survey Telescope / Calibration Systems` section:
* FiberSpectrograph:101
* FiberSpectrograph:102
* Electrometer:103