### PR TITLE
Add DREAM and ATBuilding CSCs to ASummary State view on summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.2.4
+------
+
+* Add DREAM and ATBuilding CSCs to ASummary State view on summit. `<https://github.com/lsst-ts/LOVE-manager/pull/313>`_
+
 v7.2.3
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -741,6 +741,10 @@
                       "salindex": 0
                     },
                     {
+                      "name": "DREAM",
+                      "salindex": 0
+                    },
+                    {
                       "name": "HVAC",
                       "salindex": 0
                     },
@@ -1095,6 +1099,10 @@
                     {
                       "name": "PMD",
                       "salindex": 1
+                    },
+                    {
+                      "name": "ATBuilding",
+                      "salindex": 0
                     }
                   ],
                   "Calibration Systems": [
@@ -1121,9 +1129,9 @@
             },
             "content": "CSCSummary",
             "properties": {
-              "h": 54,
+              "h": 61,
               "i": 1,
-              "w": 96,
+              "w": 98,
               "x": 0,
               "y": 0,
               "type": "component"


### PR DESCRIPTION
This PR updates the `ASummary State` view on the `ui-framework` fixtures for summit. New CSCs were added:

- `Observatory / Environment / DREAM`
- `ATCS / Support & Monitoring / ATBuilding`