### PR TITLE
Add new CSCs to summary state views: ess-ringss, ess-electric-generators and lsstcam-ocps.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.2.5
+------
+
+* Add new CSCs to summary state views: ess-ringss, ess-electric-generators and lsstcam-ocps. `<https://github.com/lsst-ts/LOVE-manager/pull/314>`_
+
 v7.2.4
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -584,6 +584,18 @@
                     {
                       "name": "ESS",
                       "salindex": 303
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 304
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 305
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 306
                     }
                   ],
                   "HigherLevel": [

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -823,6 +823,18 @@
                     {
                       "name": "ESS",
                       "salindex": 303
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 304
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 305
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 306
                     }
                   ],
                   "HigherLevel": [

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -876,6 +876,10 @@
                     },
                     {
                       "name": "OCPS",
+                      "salindex": 3
+                    },
+                    {
+                      "name": "OCPS",
                       "salindex": 101
                     },
                     {


### PR DESCRIPTION
This PR adds new ESS CSCs to the `ui-framework` fictures for summit and base:
- `Observatory / Environment / ESS:304` -> summit + base
- `Observatory / Environment / ESS:305` -> summit + base
- `Observatory / Environment / ESS:306 ` -> summit + base
- `Observatory / HigherLevel / OCPS:3 ` -> summit