### PR TITLE
Add LOVE config files references to ui-framework remote fixtures for summit, base and tucson.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.2.6
+------
+
+* Add LOVE config files references to ui-framework remote fixtures for summit, base and tucson. `<https://github.com/lsst-ts/LOVE-manager/pull/315>`_
+
 v7.2.5
 ------
 

--- a/manager/api/fixtures/initial_data_remote_base.json
+++ b/manager/api/fixtures/initial_data_remote_base.json
@@ -3,11 +3,33 @@
     "model": "api.configfile",
     "pk": 1,
     "fields": {
-      "creation_timestamp": "2020-12-29T14:21:31.040Z",
-      "update_timestamp": "2020-12-29T14:21:31.040Z",
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
       "file_name": "default.json",
       "config_file": "https://base-lsp.lsst.codes/love/manager/media/configs/default.json"
+    }
+  },
+  {
+    "model": "api.configfile",
+    "pk": 2,
+    "fields": {
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
+      "user": 1,
+      "file_name": "all_alarms.json",
+      "config_file": "https://base-lsp.lsst.codes/love/manager/media/configs/all-alarms.json"
+    }
+  },
+  {
+    "model": "api.configfile",
+    "pk": 3,
+    "fields": {
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
+      "user": 1,
+      "file_name": "no_alarms.json",
+      "config_file": "https://base-lsp.lsst.codes/love/manager/media/configs/no-alarms.json"
     }
   },
   {

--- a/manager/api/fixtures/initial_data_remote_summit.json
+++ b/manager/api/fixtures/initial_data_remote_summit.json
@@ -3,11 +3,33 @@
     "model": "api.configfile",
     "pk": 1,
     "fields": {
-      "creation_timestamp": "2020-12-29T14:21:31.040Z",
-      "update_timestamp": "2020-12-29T14:21:31.040Z",
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
       "file_name": "default.json",
       "config_file": "https://summit-lsp.lsst.codes/love/media/configs/default.json"
+    }
+  },
+  {
+    "model": "api.configfile",
+    "pk": 2,
+    "fields": {
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
+      "user": 1,
+      "file_name": "all_alarms.json",
+      "config_file": "https://summit-lsp.lsst.codes/love/media/configs/all-alarms.json"
+    }
+  },
+  {
+    "model": "api.configfile",
+    "pk": 3,
+    "fields": {
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
+      "user": 1,
+      "file_name": "no_alarms.json",
+      "config_file": "https://summit-lsp.lsst.codes/love/media/configs/no-alarms.json"
     }
   },
   {

--- a/manager/api/fixtures/initial_data_remote_tucson.json
+++ b/manager/api/fixtures/initial_data_remote_tucson.json
@@ -3,11 +3,33 @@
     "model": "api.configfile",
     "pk": 1,
     "fields": {
-      "creation_timestamp": "2020-12-29T14:21:31.040Z",
-      "update_timestamp": "2020-12-29T14:21:31.040Z",
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
       "file_name": "default.json",
       "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/default.json"
+    }
+  },
+  {
+    "model": "api.configfile",
+    "pk": 2,
+    "fields": {
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
+      "user": 1,
+      "file_name": "all_alarms.json",
+      "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/all-alarms.json"
+    }
+  },
+  {
+    "model": "api.configfile",
+    "pk": 3,
+    "fields": {
+      "creation_timestamp": "2025-03-26T00:00:00.000Z",
+      "update_timestamp": "2025-03-26T00:00:00.000Z",
+      "user": 1,
+      "file_name": "no_alarms.json",
+      "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/no-alarms.json"
     }
   },
   {


### PR DESCRIPTION
This PR updates the `api` fixtures for `remote_summit`, `remote_base` and `remote_tucson` in order to include new LOVE config files: `no-alarms.json` and `all-alarms.json`. These new config files will be stored through the source code, check https://github.com/lsst-sqre/phalanx/pull/4465 for more details.