### PR TITLE
Add Electrometer:103 to SummaryState view on BTS.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.2.7
+------
+
+* Add Electrometer:103 to SummaryState view on BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/316>`_
+
 v7.2.6
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -754,6 +754,10 @@
                     {
                       "name": "Electrometer",
                       "salindex": 102
+                    },
+                    {
+                      "name": "Electrometer",
+                      "salindex": 103
                     }
                   ],
                   "Support & Monitoring": [


### PR DESCRIPTION
This PR adds the `Electrometer:103` CSC to the `ui-framework` fixture for base on the `Simonyi Survey Telescope / Calibration Systems` section.