### PR TITLE
Add remote control rooms read-only users for LOVE summit monitoring.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.3.0
+------
+
+* Add remote control rooms read-only users for LOVE summit monitoring `<https://github.com/lsst-ts/LOVE-manager/pull/317>`_
+
 v7.2.7
 ------
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ All these variables are initialized with default variables defined in :code:`.en
 
 - `ADMIN_USER_PASS`: password for the default `admin` user, which has every permission.
 - `USER_USER_PASS`: password for the default `user` user, which has readonly permissions and cannot execute commands.
-- `CMD_USER_PASS`: password for the default `cmd` user, which can execute commands.
+- `CMD_USER_PASS`: password for the default `cmd_user` user, which can execute commands.
 - `REMOTE_BASE_USER_PASS`: password for the default `base_control_room` user, which has readonly permissions but can create views.
 - `REMOTE_TUCSON_USER_PASS`: password for the default `tucson_control_room` user, which has readonly permissions but can create views.
 - `REMOTE_SLAC_USER_PASS`: password for the default `slac_control_room` user, which has readonly permissions but can create views.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ All these variables are initialized with default variables defined in :code:`.en
 
 - `ADMIN_USER_PASS`: password for the default `admin` user, which has every permission.
 - `USER_USER_PASS`: password for the default `user` user, which has readonly permissions and cannot execute commands.
-- `CMD_USER_PASS`: password for the default `cmd` user, which has readonly permissions but can execute commands.
+- `CMD_USER_PASS`: password for the default `cmd` user, which can execute commands.
+- `REMOTE_BASE_USER_PASS`: password for the default `base_control_room` user, which has readonly permissions but can create views.
+- `REMOTE_TUCSON_USER_PASS`: password for the default `tucson_control_room` user, which has readonly permissions but can create views.
+- `REMOTE_SLAC_USER_PASS`: password for the default `slac_control_room` user, which has readonly permissions but can create views.
 - `SECRET_KEY`: overrides Django's SECRET_KEY, if not defined the default value (public in this repo) will be used.
 - `REDIS_HOST`: the location of the redis host that implements the `Channels Layer`.
 - `REDIS_PORT`: the port that the `redis` server is listening to.

--- a/manager/api/management/commands/createusers.py
+++ b/manager/api/management/commands/createusers.py
@@ -25,9 +25,17 @@ from argparse import RawTextHelpFormatter
 from django.contrib.auth.models import Group, Permission, User
 from django.core.management.base import BaseCommand
 
+# Default users names
 user_username = "user"
 cmd_user_username = "cmd_user"
 admin_username = "admin"
+
+# Remote control users names
+remote_base_username = "base_control_room"
+remote_tucson_username = "tucson_control_room"
+remote_slac_username = "slac_control_room"
+
+# Default groups names
 cmd_groupname = "cmd"
 ui_framework_groupname = "ui_framework"
 
@@ -35,20 +43,31 @@ ui_framework_groupname = "ui_framework"
 class Command(BaseCommand):
     """Django command to create the initial users with their permissions.
 
-    It creates 4 users with the following characteristics and permissions:
+    It creates 3 users with the following characteristics and permissions:
 
-    - "admin": has all the permissions, it is a Django superuser
+    - "admin": has all the permissions, it is a Django superuser.
     - "user": basic user with no commands execution permissions
-    but with permissions to add, edit and delete views
-    - "cmd_user": basic user with commands execution permissions
+    but with permissions to add, edit and delete views.
+    - "cmd_user": basic user with commands execution permissions.
 
-    It also creates 2 Groups:
-    "cmd_group", which defines the commands execution permissions.
-    "ui_framework_group", which defines the permissions
-    to add, edit and delete views.
+    It also creates 3 users for remote monitoring support
+    with no commands execution permissions
+    but with permissions to add, edit and delete views:
+
+    - "base_control_room": user for the Base control room.
+    - "tucson_control_room": user for the Tucson control room.
+    - "slac_control_room": user for the SLAC control room.
+
+    It also creates 2 groups:
+
+    - "cmd_group": defines the commands execution permissions.
+    - "ui_framework_group": defines the permissions to add,
+    edit and delete views.
 
     "cmd_user" user belongs to "cmd_group".
-    "cmd_user" and "user" user belong to "ui_framework_group".
+    "cmd_user", "user", "base_control_room",
+    "tucson_control_room" and "slac_control_room"
+    users belong to "ui_framework_group".
 
     The command receives arguments to set the passwords of the users,
     run `python manage.py createusers --help` for help.
@@ -56,19 +75,32 @@ class Command(BaseCommand):
 
     help = """Django command to create the initial users with their permissions.\n
 
-    It creates 4 users with the following characteristics and permissions:
+    It creates 3 users with the following characteristics and permissions:
 
-    - "admin": has all the permissions, it is a Django superuser
+    - "admin": has all the permissions, it is a Django superuser.
     - "user": basic user with no commands execution permissions,
-    but with permissions to add, edit and delete views
+    but with permissions to add, edit and delete views.
     - "cmd_user": basic user with commands execution permissions
+    and with permissions to add, edit and delete views.
 
-    It also creates 2 Groups:
-    "cmd_group", which defines the commands execution permissions.
-    "ui_framework_group", which defines the permissions to add, edit and delete views.
+    It also creates 3 users for remote monitoring support
+    with no commands execution permissions
+    but with permissions to add, edit and delete views:
+
+    - "base_control_room": user for the Base control room.
+    - "tucson_control_room": user for the Tucson control room.
+    - "slac_control_room": user for the SLAC control room.
+
+    It also creates 2 groups:
+
+    - "cmd_group": defines the commands execution permissions.
+    - "ui_framework_group": defines the permissions to add,
+    edit and delete views.
 
     "cmd_user" user belongs to "cmd_group".
-    "cmd_user" and "user" user belong to "ui_framework_group"."""
+    "cmd_user", "user", "base_control_room",
+    "tucson_control_room" and "slac_control_room"
+    users belong to "ui_framework_group"."""
 
     requires_migrations_checks = True
     stealth_options = ("stdin",)
@@ -112,6 +144,18 @@ class Command(BaseCommand):
             "--cmduserpass",
             help='Specifies password for the users with cmd permissions ("cmd_user").',
         )
+        parser.add_argument(
+            "--remotebaseuserpass",
+            help='Specifies password for the user for remote monitoring at Base ("base_control_room").',
+        )
+        parser.add_argument(
+            "--remotetucsonuserpass",
+            help='Specifies password for the user for remote monitoring at Tucson ("tucson_control_room").',
+        )
+        parser.add_argument(
+            "--remoteslacuserpass",
+            help='Specifies password for the user for remote monitoring at SLAC ("slac_control_room").',
+        )
 
     def handle(self, *args, **options):
         """Execute the command, which creates the users.
@@ -124,9 +168,12 @@ class Command(BaseCommand):
             Dictionary with addittional
             keyword arguments (indexed by keys in the dict)
         """
-        admin_password = options["adminpass"]
-        user_password = options["userpass"]
-        cmd_password = options["cmduserpass"]
+        admin_password = options.get("adminpass")
+        user_password = options.get("userpass")
+        cmd_password = options.get("cmduserpass")
+        remote_base_password = options.get("remotebaseuserpass")
+        remote_tucson_password = options.get("remotetucsonuserpass")
+        remote_slac_password = options.get("remoteslacuserpass")
 
         # Create groups
         ui_framework_group = self._create_ui_framework_group()
@@ -151,6 +198,25 @@ class Command(BaseCommand):
             cmd_user = self._create_user(cmd_user_username, cmd_password)
             ui_framework_group.user_set.add(cmd_user)
             cmd_group.user_set.add(cmd_user)
+
+        # Create remote users
+        if remote_base_password is not None:
+            remote_base_user = self._create_user(
+                remote_base_username, remote_base_password
+            )
+            ui_framework_group.user_set.add(remote_base_user)
+
+        if remote_tucson_password is not None:
+            remote_tucson_user = self._create_user(
+                remote_tucson_username, remote_tucson_password
+            )
+            ui_framework_group.user_set.add(remote_tucson_user)
+
+        if remote_slac_password is not None:
+            remote_slac_user = self._create_user(
+                remote_slac_username, remote_slac_password
+            )
+            ui_framework_group.user_set.add(remote_slac_user)
 
     def _create_user(self, username, password):
         """Create a given user, if it does not exist. Return it anyway.

--- a/manager/api/management/commands/createusers.py
+++ b/manager/api/management/commands/createusers.py
@@ -48,7 +48,8 @@ class Command(BaseCommand):
     - "admin": has all the permissions, it is a Django superuser.
     - "user": basic user with no commands execution permissions
     but with permissions to add, edit and delete views.
-    - "cmd_user": basic user with commands execution permissions.
+    - "cmd_user": basic user with commands execution permissions
+    and with permissions to add, edit and delete views.
 
     It also creates 3 users for remote monitoring support
     with no commands execution permissions

--- a/manager/api/management/commands/tests.py
+++ b/manager/api/management/commands/tests.py
@@ -214,3 +214,22 @@ class CreateusersTestCase(TestCase):
 
         cmd_group = Group.objects.filter(name=cmd_groupname).first()
         self.assertTrue(cmd_group, "The {} group was not created".format(cmd_groupname))
+
+    def test_command_doesnt_create_users_if_not_specified(self):
+        """Test that the command does not create users if not specified."""
+        # Arrange:
+        old_users_num = User.objects.count()
+        old_groups_num = Group.objects.count()
+        command = Command()
+        # Act:
+        options = {}
+        command.handle(*[], **options)
+        # Assert:
+        self.assertEqual(
+            User.objects.count(),
+            old_users_num,
+            "There are new users even when not specified",
+        )
+        self.assertEqual(
+            Group.objects.count(), old_groups_num + 2, "There is no new group"
+        )

--- a/manager/api/management/commands/tests.py
+++ b/manager/api/management/commands/tests.py
@@ -24,6 +24,9 @@ from api.management.commands.createusers import (
     admin_username,
     cmd_groupname,
     cmd_user_username,
+    remote_base_username,
+    remote_slac_username,
+    remote_tucson_username,
     user_username,
 )
 from django.contrib.auth.models import Group, User
@@ -47,11 +50,14 @@ class CreateusersTestCase(TestCase):
             "adminpass": "admin_pass",
             "userpass": "user_pass",
             "cmduserpass": "cmd_pass",
+            "remotebaseuserpass": "remote_base_pass",
+            "remotetucsonuserpass": "remote_tucson_pass",
+            "remoteslacuserpass": "remote_slac_pass",
         }
         command.handle(*[], **options)
         # Assert:
         self.assertEqual(
-            User.objects.count(), old_users_num + 3, "There are no new users"
+            User.objects.count(), old_users_num + 6, "There are no new users"
         )
         self.assertEqual(
             Group.objects.count(), old_groups_num + 2, "There is no new group"
@@ -59,13 +65,30 @@ class CreateusersTestCase(TestCase):
         admin = User.objects.filter(username=admin_username).first()
         user = User.objects.filter(username=user_username).first()
         cmd_user = User.objects.filter(username=cmd_user_username).first()
-        cmd_group = Group.objects.filter(name=cmd_groupname).first()
+
+        base_control_room = User.objects.filter(username=remote_base_username).first()
+        tucson_control_room = User.objects.filter(
+            username=remote_tucson_username
+        ).first()
+        slac_control_room = User.objects.filter(username=remote_slac_username).first()
+
         self.assertTrue(admin, "The {} user was not created".format(admin_username))
         self.assertTrue(user, "The {} user was not created".format(user_username))
         self.assertTrue(
             cmd_user, "The {} user was not created".format(cmd_user_username)
         )
-        self.assertTrue(cmd_group, "The {} group was not created".format(cmd_groupname))
+        self.assertTrue(
+            base_control_room,
+            "The {} user was not created".format(remote_base_username),
+        )
+        self.assertTrue(
+            tucson_control_room,
+            "The {} user was not created".format(remote_tucson_username),
+        )
+        self.assertTrue(
+            slac_control_room,
+            "The {} user was not created".format(remote_slac_username),
+        )
         self.assertTrue(
             admin.has_perm(cmd_permission_codename),
             "{} user should have cmd_execute permissions".format(admin_username),
@@ -78,6 +101,27 @@ class CreateusersTestCase(TestCase):
             cmd_user.has_perm(cmd_permission_codename),
             "{} user should have cmd_execute permissions".format(cmd_user_username),
         )
+        self.assertFalse(
+            base_control_room.has_perm(cmd_permission_codename),
+            "{} user should not have cmd_execute permissions".format(
+                remote_base_username
+            ),
+        )
+        self.assertFalse(
+            tucson_control_room.has_perm(cmd_permission_codename),
+            "{} user should not have cmd_execute permissions".format(
+                remote_tucson_username
+            ),
+        )
+        self.assertFalse(
+            slac_control_room.has_perm(cmd_permission_codename),
+            "{} user should not have cmd_execute permissions".format(
+                remote_slac_username
+            ),
+        )
+
+        cmd_group = Group.objects.filter(name=cmd_groupname).first()
+        self.assertTrue(cmd_group, "The {} group was not created".format(cmd_groupname))
 
     def test_command_sets_permissions_even_if_users_already_existed(self):
         """Test that the command does not fail if the users already existed."""
@@ -99,11 +143,29 @@ class CreateusersTestCase(TestCase):
             email="{}@fake.com".format(cmd_user_username),
             password="dummy-pass",
         )
+        User.objects.create_user(
+            username=remote_base_username,
+            email="{}@fake.com".format(remote_base_username),
+            password="dummy-pass",
+        )
+        User.objects.create_user(
+            username=remote_tucson_username,
+            email="{}@fake.com".format(remote_tucson_username),
+            password="dummy-pass",
+        )
+        User.objects.create_user(
+            username=remote_slac_username,
+            email="{}@fake.com".format(remote_slac_username),
+            password="dummy-pass",
+        )
         # Act:
         options = {
             "adminpass": "admin_pass",
             "userpass": "user_pass",
             "cmduserpass": "cmd_pass",
+            "remotebaseuserpass": "remote_base_pass",
+            "remotetucsonuserpass": "remote_tucson_pass",
+            "remoteslacuserpass": "remote_slac_pass",
         }
         command.handle(*[], **options)
         # Assert:
@@ -113,8 +175,12 @@ class CreateusersTestCase(TestCase):
         admin = User.objects.filter(username=admin_username).first()
         user = User.objects.filter(username=user_username).first()
         cmd_user = User.objects.filter(username=cmd_user_username).first()
-        cmd_group = Group.objects.filter(name=cmd_groupname).first()
-        self.assertTrue(cmd_group, "The {} group was not created".format(cmd_groupname))
+        base_control_room = User.objects.filter(username=remote_base_username).first()
+        tucson_control_room = User.objects.filter(
+            username=remote_tucson_username
+        ).first()
+        slac_control_room = User.objects.filter(username=remote_slac_username).first()
+
         self.assertTrue(
             admin.has_perm(cmd_permission_codename),
             "{} user should have cmd_execute permissions".format(admin_username),
@@ -127,3 +193,24 @@ class CreateusersTestCase(TestCase):
             cmd_user.has_perm(cmd_permission_codename),
             "{} user should have cmd_execute permissions".format(cmd_user_username),
         )
+        self.assertFalse(
+            base_control_room.has_perm(cmd_permission_codename),
+            "{} user should not have cmd_execute permissions".format(
+                remote_base_username
+            ),
+        )
+        self.assertFalse(
+            tucson_control_room.has_perm(cmd_permission_codename),
+            "{} user should not have cmd_execute permissions".format(
+                remote_tucson_username
+            ),
+        )
+        self.assertFalse(
+            slac_control_room.has_perm(cmd_permission_codename),
+            "{} user should not have cmd_execute permissions".format(
+                remote_slac_username
+            ),
+        )
+
+        cmd_group = Group.objects.filter(name=cmd_groupname).first()
+        self.assertTrue(cmd_group, "The {} group was not created".format(cmd_groupname))

--- a/manager/runserver.sh
+++ b/manager/runserver.sh
@@ -12,7 +12,15 @@ echo -e "\nApplying migrations"
 python manage.py migrate
 
 echo -e "\nCreating default users"
-python manage.py createusers --adminpass ${ADMIN_USER_PASS} --userpass ${USER_USER_PASS}
+if [ "${LOVE_SITE}" == "summit" ]; then
+  python manage.py createusers --adminpass ${ADMIN_USER_PASS} --userpass ${USER_USER_PASS} \
+  --remotebaseuserpass ${REMOTE_BASE_USER_PASS} \
+  --remotetucsonuserpass ${REMOTE_TUCSON_USER_PASS} \
+  --remoteslacuserpass ${REMOTE_SLAC_USER_PASS}
+else
+  python manage.py createusers --adminpass ${ADMIN_USER_PASS} --userpass ${USER_USER_PASS}
+fi
+
 if [ -z ${LOVE_SITE} ]; then
   love_site="summit"
 else


### PR DESCRIPTION
This PR adds three new users to the `createusers` command:

- `base_control_room`
- `tucson_control_room`
- `slac_control_room`

In adition to the RSP Summit 1password vault, passwords for these users are also stored in the Operators 1password vault.