### PR TITLE
Add serious alarms config file reference to ui-framework remote fixtures for summit, base and tucson.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.3.1
+------
+
+* Add serious alarms config file reference to ui-framework remote fixtures for summit, base and tucson. `<https://github.com/lsst-ts/LOVE-manager/pull/318>`_
+
 v7.3.0
 ------
 

--- a/manager/api/fixtures/initial_data_remote_base.json
+++ b/manager/api/fixtures/initial_data_remote_base.json
@@ -17,8 +17,8 @@
       "creation_timestamp": "2025-03-26T00:00:00.000Z",
       "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
-      "file_name": "all_alarms.json",
-      "config_file": "https://base-lsp.lsst.codes/love/manager/media/configs/all-alarms.json"
+      "file_name": "serious-alarms.json",
+      "config_file": "https://base-lsp.lsst.codes/love/manager/media/configs/serious-alarms.json"
     }
   },
   {
@@ -28,7 +28,7 @@
       "creation_timestamp": "2025-03-26T00:00:00.000Z",
       "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
-      "file_name": "no_alarms.json",
+      "file_name": "no-alarms.json",
       "config_file": "https://base-lsp.lsst.codes/love/manager/media/configs/no-alarms.json"
     }
   },

--- a/manager/api/fixtures/initial_data_remote_summit.json
+++ b/manager/api/fixtures/initial_data_remote_summit.json
@@ -17,8 +17,8 @@
       "creation_timestamp": "2025-03-26T00:00:00.000Z",
       "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
-      "file_name": "all_alarms.json",
-      "config_file": "https://summit-lsp.lsst.codes/love/media/configs/all-alarms.json"
+      "file_name": "serious-alarms.json",
+      "config_file": "https://summit-lsp.lsst.codes/love/media/configs/serious-alarms.json"
     }
   },
   {
@@ -28,7 +28,7 @@
       "creation_timestamp": "2025-03-26T00:00:00.000Z",
       "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
-      "file_name": "no_alarms.json",
+      "file_name": "no-alarms.json",
       "config_file": "https://summit-lsp.lsst.codes/love/media/configs/no-alarms.json"
     }
   },

--- a/manager/api/fixtures/initial_data_remote_tucson.json
+++ b/manager/api/fixtures/initial_data_remote_tucson.json
@@ -17,8 +17,8 @@
       "creation_timestamp": "2025-03-26T00:00:00.000Z",
       "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
-      "file_name": "all_alarms.json",
-      "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/all-alarms.json"
+      "file_name": "serious-alarms.json",
+      "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/serious-alarms.json"
     }
   },
   {
@@ -28,7 +28,7 @@
       "creation_timestamp": "2025-03-26T00:00:00.000Z",
       "update_timestamp": "2025-03-26T00:00:00.000Z",
       "user": 1,
-      "file_name": "no_alarms.json",
+      "file_name": "no-alarms.json",
       "config_file": "https://tucson-teststand.lsst.codes/love/manager/media/configs/no-alarms.json"
     }
   },


### PR DESCRIPTION
This PR updates the `api` fixtures for `remote_summit`, `remote_base` and `remote_tucson` in order to add a `serious-alarms.json` LOVE config file as the all alarms one is the default one now.

See also https://github.com/lsst-sqre/phalanx/pull/4546 for more details.