### PR TITLE
Add new ESS 114, 115, 116 and 116 for M1M3 thermal scanners to Summit and BTS.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.3.2
+------
+
+* Add new ESS 114, 115, 116 and 116 for M1M3 thermal scanners to Summit and BTS. `<https://github.com/lsst-ts/LOVE-manager/pull/319>`_
+
 v7.3.1
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -563,6 +563,22 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 114
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 115
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 116
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 117
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 201
                     },
                     {

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -798,6 +798,22 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 114
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 115
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 116
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 117
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 201
                     },
                     {


### PR DESCRIPTION
This PR adds new ESS CSCs: 114, 115, 116 and 117 to the Summit and BTS `ui-framework` fixtures on the `Observatory / Environment` section.