### PR TITLE
Add ESS:2 and MTReflector to sumary state views on BTS and Summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.3.3
+------
+
+* Add ESS:2 and MTReflector to sumary state views on BTS and Summit. `<https://github.com/lsst-ts/LOVE-manager/pull/320>`_
+
 v7.3.2
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -778,6 +778,10 @@
                     {
                       "name": "Electrometer",
                       "salindex": 103
+                    },
+                    {
+                      "name": "MTReflector",
+                      "salindex": 0
                     }
                   ],
                   "Support & Monitoring": [

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -523,6 +523,10 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 2
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 104
                     },
                     {

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -1079,6 +1079,10 @@
                     {
                       "name": "LinearStage",
                       "salindex": 104
+                    },
+                    {
+                      "name": "MTReflector",
+                      "salindex": 0
                     }
                   ]
                 },

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -758,6 +758,10 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 2
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 104
                     },
                     {


### PR DESCRIPTION
This PR adds new CSCs to the BTS and Summit `ui-framework` fixtures:

- `Observatory / Environment / ESS:2`.
- `Simonyi Survey Telescope / Calibration Systems / MTReflector`.