### PR TITLE
Add new ESS 118, 119 and 120 to ui-framework fixtures on summit, base and tucson.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.3.5
+------
+
+* Add new ESS 118, 119 and 120 to ui-framework fixtures on summit, base and tucson. `<https://github.com/lsst-ts/LOVE-manager/pull/323>`_
+
 v7.3.4
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -583,6 +583,18 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 118
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 119
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 120
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 201
                     },
                     {

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -818,6 +818,18 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 118
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 119
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 120
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 201
                     },
                     {

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -583,6 +583,18 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 118
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 119
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 120
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 201
                     },
                     {


### PR DESCRIPTION
This PR adds new CSCs to the Summit, BTS and TTS `ui-framework` fixtures:

- `Observatory / Environment / ESS:118`.
- `Observatory / Environment / ESS:119`.
- `Observatory / Environment / ESS:120`.