### PR TITLE
Add Jira tickets and EFD most recent timeseries query endpoints.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.4.0
+------
+
+* Add Jira tickets and EFD most recent timeseries query endpoints. `<https://github.com/lsst-ts/LOVE-manager/pull/325>`_
+
 v7.3.5
 ------
 

--- a/manager/api/management/commands/createusers.py
+++ b/manager/api/management/commands/createusers.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
         args: list
             List of arguments
         kwargs: dict
-            Dictionary with addittional
+            Dictionary with additional
             keyword arguments (indexed by keys in the dict)
         """
         parser = super(Command, self).create_parser(*args, **kwargs)
@@ -166,7 +166,7 @@ class Command(BaseCommand):
         args: list
             List of arguments
         kwargs: dict
-            Dictionary with addittional
+            Dictionary with additional
             keyword arguments (indexed by keys in the dict)
         """
         admin_password = options.get("adminpass")

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -17,20 +17,29 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-
+import json
 import os
 import random
+from datetime import timedelta
 from unittest.mock import patch
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
+import astropy
 import pytest
 import requests
 import rest_framework
+from api.models import Token
+from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
 
 from manager.utils import (
+    OBS_SYSTEMS_FIELD,
     OBS_TIME_LOST_FIELD,
     get_jira_obs_report,
+    get_obsday_from_tai,
+    get_obsday_to_tai,
     handle_jira_payload,
     jira_comment,
     jira_ticket,
@@ -535,6 +544,9 @@ class JiraTestCase(TestCase):
                     "fields": {
                         "summary": "Issue title",
                         OBS_TIME_LOST_FIELD: 13.6,
+                        OBS_SYSTEMS_FIELD: json.loads(
+                            JIRA_OBS_SYSTEMS_SELECTION_EXAMPLE
+                        ),
                         "creator": {"displayName": "user"},
                         "created": "2024-11-27T12:00:00.00000",
                     },
@@ -615,3 +627,281 @@ class JiraTestCase(TestCase):
         }
         with pytest.raises(ValueError):
             get_jira_obs_report(request_data)
+
+
+class JiraAPITestCase(TestCase):
+    def setUp(self):
+        """Define the test suite setup."""
+        # Arrange
+        self.client = APIClient()
+
+        user_normal_obj = {
+            "username": "user-normal",
+            "password": "password",
+            "email": "test@user.cl",
+            "first_name": "user-normal",
+            "last_name": "",
+        }
+
+        self.user_normal = User.objects.create_user(
+            username=user_normal_obj["username"],
+            password=user_normal_obj["password"],
+            email=user_normal_obj["email"],
+            first_name=user_normal_obj["first_name"],
+            last_name=user_normal_obj["last_name"],
+        )
+        self.token_user_normal = Token.objects.create(user=self.user_normal)
+
+        self.headers = {
+            "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",
+            "content-type": "application/json",
+        }
+
+    def test_jira_tickets_report(self):
+        """Test jira tickets report endpoint."""
+        # Arrange:
+        mock_jira_patcher = patch("requests.get")
+        mock_jira_client = mock_jira_patcher.start()
+
+        jira_project = "OBS"
+
+        url_call_1 = (
+            f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/myself"
+        )
+        response_1 = requests.Response()
+        response_1.status_code = 200
+        response_1.json = lambda: {
+            "timeZone": "America/Phoenix",
+        }
+
+        # American/Phoenix timezone is UTC-7
+        day_obs = "20241127"
+        jql_query = (
+            f"project = '{jira_project}' "
+            "AND created >= '2024-11-27 05:00' "
+            "AND created <= '2024-11-28 05:00'"
+        )
+        url_call_2 = (
+            f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
+            f"/rest/api/latest/search?jql={quote(jql_query)}"
+        )
+        response_2 = requests.Response()
+        response_2.status_code = 200
+        response_2.json = lambda: {
+            "issues": [
+                {
+                    "key": "LOVE-XX",
+                    "fields": {
+                        "summary": "Issue title",
+                        OBS_TIME_LOST_FIELD: 13.6,
+                        OBS_SYSTEMS_FIELD: json.loads(
+                            JIRA_OBS_SYSTEMS_SELECTION_EXAMPLE
+                        ),
+                        "creator": {"displayName": "user"},
+                        "created": "2024-11-27T12:00:00.00000",
+                    },
+                }
+            ]
+        }
+
+        mock_jira_client.side_effect = [response_1, response_2]
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+
+        # Act:
+        base_url = reverse("Jira-tickets-report", kwargs={"project": jira_project})
+        query_params = {"day_obs": day_obs}
+        url = f"{base_url}?{urlencode(query_params)}"
+        response = self.client.get(url, format="json")
+
+        mock_jira_client.assert_any_call(url_call_1, headers=self.headers)
+        mock_jira_client.assert_any_call(url_call_2, headers=self.headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+        mock_jira_patcher.stop()
+
+    def test_jira_tickets_report_without_day_obs(self):
+        """Test jira tickets report endpoint
+        without passing a day_obs query param. This means the current
+        day_obs will be used."""
+        # Arrange:
+        mock_jira_patcher = patch("requests.get")
+        mock_jira_client = mock_jira_patcher.start()
+
+        jira_project = "OBS"
+
+        url_call_1 = (
+            f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/myself"
+        )
+        response_1 = requests.Response()
+        response_1.status_code = 200
+        response_1.json = lambda: {
+            "timeZone": "America/Phoenix",
+        }
+
+        # Create a datetime object for the current date at 12:00 UTC
+        current_tai_datetime = astropy.time.Time.now().tai.datetime
+        current_day_obs = get_obsday_from_tai(current_tai_datetime)
+        twelve_utc = get_obsday_to_tai(current_day_obs)
+        next_day = twelve_utc + timedelta(days=1)
+        twelve_utc_day = twelve_utc.strftime("%Y-%m-%d")
+        next_day_day = next_day.strftime("%Y-%m-%d")
+
+        # American/Phoenix timezone is UTC-7
+        jql_query = (
+            f"project = '{jira_project}' "
+            f"AND created >= '{twelve_utc_day} 05:00' "
+            f"AND created <= '{next_day_day} 05:00'"
+        )
+        url_call_2 = (
+            f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
+            f"/rest/api/latest/search?jql={quote(jql_query)}"
+        )
+        response_2 = requests.Response()
+        response_2.status_code = 200
+        response_2.json = lambda: {
+            "issues": [
+                {
+                    "key": "LOVE-XX",
+                    "fields": {
+                        "summary": "Issue title",
+                        OBS_TIME_LOST_FIELD: 13.6,
+                        OBS_SYSTEMS_FIELD: json.loads(
+                            JIRA_OBS_SYSTEMS_SELECTION_EXAMPLE
+                        ),
+                        "creator": {"displayName": "user"},
+                        "created": f"{twelve_utc_day}T12:00:00.00000",
+                    },
+                }
+            ]
+        }
+
+        mock_jira_client.side_effect = [response_1, response_2]
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+
+        # Act:
+        url = reverse("Jira-tickets-report", kwargs={"project": jira_project})
+        response = self.client.get(url, format="json")
+
+        mock_jira_client.assert_any_call(url_call_1, headers=self.headers)
+        mock_jira_client.assert_any_call(url_call_2, headers=self.headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+        mock_jira_patcher.stop()
+
+    def test_jira_tickets_report_jira_fail(self):
+        """Test jira tickets report endpoint with fail response from Jira."""
+        # Arrange:
+        mock_jira_patcher = patch("requests.get")
+        mock_jira_client = mock_jira_patcher.start()
+
+        jira_project = "OBS"
+
+        url_call_1 = (
+            f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/myself"
+        )
+
+        # American/Phoenix timezone is UTC-7
+        day_obs = "20241127"
+        jql_query = (
+            f"project = '{jira_project}' "
+            "AND created >= '2024-11-27 05:00' "
+            "AND created <= '2024-11-28 05:00'"
+        )
+        url_call_2 = (
+            f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
+            f"/rest/api/latest/search?jql={quote(jql_query)}"
+        )
+
+        failed_response = requests.Response()
+        failed_response.status_code = 500
+
+        response_1_good = requests.Response()
+        response_1_good.status_code = 200
+        response_1_good.json = lambda: {
+            "timeZone": "America/Phoenix",
+        }
+
+        response_2_good = requests.Response()
+        response_2_good.status_code = 200
+        response_2_good.json = lambda: {
+            "issues": [
+                {
+                    "key": "LOVE-XX",
+                    "fields": {
+                        "summary": "Issue title",
+                        OBS_TIME_LOST_FIELD: 13.6,
+                        OBS_SYSTEMS_FIELD: json.loads(
+                            JIRA_OBS_SYSTEMS_SELECTION_EXAMPLE
+                        ),
+                        "creator": {"displayName": "user"},
+                        "created": "2024-11-27T12:00:00.00000",
+                    },
+                }
+            ]
+        }
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+        base_url = reverse("Jira-tickets-report", kwargs={"project": jira_project})
+        query_params = {"day_obs": day_obs}
+        url = f"{base_url}?{urlencode(query_params)}"
+
+        # First response is bad and second is good
+        mock_jira_client.side_effect = [failed_response, response_2_good]
+
+        # Act:
+        response = self.client.get(url, format="json")
+
+        mock_jira_client.assert_any_call(url_call_1, headers=self.headers)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.data["error"],
+            f"Error getting user timezone from {os.environ.get('JIRA_API_HOSTNAME')}",
+        )
+
+        # First response is good and second is bad
+        mock_jira_client.side_effect = [response_1_good, failed_response]
+
+        # Act:
+        response = self.client.get(url, format="json")
+
+        mock_jira_client.assert_any_call(url_call_1, headers=self.headers)
+        mock_jira_client.assert_any_call(url_call_2, headers=self.headers)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.data["error"],
+            f"Error getting issues from {os.environ.get('JIRA_API_HOSTNAME')}",
+        )
+
+        mock_jira_patcher.stop()
+
+    def test_jira_tickets_report_invalid_project(self):
+        """Test jira tickets report endpoint with invalid project."""
+        # Arrange:
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Token " + self.token_user_normal.key
+        )
+        base_url = reverse("Jira-tickets-report", kwargs={"project": "INVALID"})
+
+        # Act:
+        response = self.client.get(base_url, format="json")
+
+        # Assert:
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"],
+            "Invalid project",
+        )

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -531,9 +531,10 @@ class NightReportTestCase(TestCase):
         self.token_user_normal = Token.objects.create(user=self.user_normal)
 
         self.payload = {
-            "telescope": "AuxTel",
-            "suummary": "summary",
-            "telescope_status": "telescope_status",
+            "summary": "summary",
+            "weather": "weather summary",
+            "maintel_summary": "maintel summary",
+            "auxtel_summary": "auxtel summary",
             "confluence_url": "https://localhost/confluence",
             "observers_crew": ["User1", "User2"],
         }
@@ -541,10 +542,11 @@ class NightReportTestCase(TestCase):
         self.response_report = {
             "id": "e75b07b6-a422-4cd7-99fc-95b0046645b0",
             "site_id": "base",
-            "telescope": "Simonyi",
             "day_obs": 0,
             "summary": "string",
-            "telescope_status": "string",
+            "weather": "string",
+            "maintel_summary": "string",
+            "auxtel_summary": "string",
             "confluence_url": "string",
             "user_id": "string",
             "user_agent": "string",
@@ -554,6 +556,29 @@ class NightReportTestCase(TestCase):
             "date_invalidated": None,
             "parent_id": None,
             "observers_crew": [],
+        }
+
+        self.send_report_payload = {
+            "observatory_status": {
+                "simonyiAzimuth": "0.00°",
+                "simonyiElevation": "0.00°",
+                "simonyiDomeAzimuth": "0.00°",
+                "simonyiRotator": "0.00°",
+                "simonyiMirrorCoversState": "UNKNOWN",
+                "simonyiOilSupplySystemState": "UNKNOWN",
+                "simonyiPowerSupplySystemState": "UNKNOWN",
+                "simonyiLockingPinsSystemState": "UNKNOWN",
+                "auxtelAzimuth": "0.00°",
+                "auxtelElevation": "0.00°",
+                "auxtelDomeAzimuth": "0.00°",
+                "auxtelMirrorCoversState": "UNKNOWN",
+            },
+            "cscs_status": {
+                "CSC:0": "UNKNOWN",
+                "CSC:1": "UNKNOWN",
+                "CSC:2": "UNKNOWN",
+                "CSC:3": "UNKNOWN",
+            },
         }
 
     def test_nightreport_list(self):
@@ -673,8 +698,8 @@ class NightReportTestCase(TestCase):
         )
 
         # Act:
-        url = reverse("OLE-nightreport-send-report", args=[1])
-        response = self.client.post(url)
+        url = reverse("OLE-nightreport-send-report", args=[self.response_report["id"]])
+        response = self.client.post(url, data=self.send_report_payload, format="json")
         self.assertEqual(response.status_code, 200)
 
         mock_ole_patcher_get.stop()
@@ -701,7 +726,7 @@ class NightReportTestCase(TestCase):
         )
 
         # Act:
-        url = reverse("OLE-nightreport-send-report", args=[1])
+        url = reverse("OLE-nightreport-send-report", args=[self.response_report["id"]])
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, {"error": "Night report already sent"})

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -110,6 +110,11 @@ urlpatterns = [
         api.views.ole_send_night_report,
         name="OLE-nightreport-send-report",
     ),
+    path(
+        "jira/report/<project>/",
+        api.views.get_jira_tickets_report,
+        name="Jira-tickets-report",
+    ),
 ]
 router.register("user", UserViewSet)
 router.register("configfile", ConfigFileViewSet)

--- a/manager/api/urls.py
+++ b/manager/api/urls.py
@@ -82,6 +82,11 @@ urlpatterns = [
     path("config", api.views.get_config, name="config"),
     path("config-set", api.views.set_config_selected, name="config-set"),
     path("efd/timeseries", api.views.query_efd_timeseries, name="EFD-timeseries"),
+    path(
+        "efd/top_timeseries",
+        api.views.query_efd_most_recent_timeseries,
+        name="EFD-top-timeseries",
+    ),
     path("efd/logmessages", api.views.query_efd_logs, name="EFD-logmessages"),
     path("efd/efd_clients", api.views.query_efd_clients, name="EFD-clients"),
     path(

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -105,9 +105,9 @@ def validate_token(request, *args, **kwargs):
     request: Request
         The Request object
     args: list
-        List of addittional arguments. Currenlty unused
+        List of additional arguments. Currenlty unused
     kwargs: dict
-        Dictionary with addittional keyword arguments
+        Dictionary with additional keyword arguments
         (indexed by keys in the dict), one optional parameter
         that could be expeted is `flags`
 
@@ -228,9 +228,9 @@ class CustomObtainAuthToken(ObtainAuthToken):
         request: Request
             The Request object
         args: list
-            List of addittional arguments. Currenlty unused
+            List of additional arguments. Currenlty unused
         kwargs: dict
-            Dictionary with addittional keyword arguments
+            Dictionary with additional keyword arguments
             (indexed by keys in the dict). Currenlty unused
 
         Returns
@@ -310,9 +310,9 @@ class CustomSwapAuthToken(ObtainAuthToken):
         request: Request
             The Request object
         args: list
-            List of addittional arguments. Currently unused
+            List of additional arguments. Currently unused
         kwargs: dict
-            Dictionary with addittional keyword arguments
+            Dictionary with additional keyword arguments
             (indexed by keys in the dict). Currenlty unused
 
         Returns
@@ -841,7 +841,7 @@ def query_efd_timeseries(request, *args, **kwargs):
                 resample conversion, e.g. '15min', '10S'
             efd_instance (required): The specific EFD instance to query
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dict of additional arguments. Currently unused
 
@@ -872,7 +872,7 @@ def query_efd_most_recent_timeseries(request, *args, **kwargs):
             num: Int specifying the number of most recent records to retrieve.
             efd_instance (required): The specific EFD instance to query
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dict of additional arguments. Currently unused
 
@@ -916,7 +916,7 @@ def query_efd_logs(request, *args, **kwargs):
                 }
             efd_instance (required): The specific EFD instance to query
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dict of additional arguments. Currently unused
 
@@ -964,7 +964,7 @@ def tcs_aux_command(request, *args, **kwargs):
     request: Request
         The Request object
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dictionary with request arguments.
         Request should contain the following:
@@ -998,7 +998,7 @@ def tcs_aux_docstrings(request, *args, **kwargs):
     request: Request
         The Request object
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dictionary with request arguments. Currently unused
 
@@ -1025,7 +1025,7 @@ def tcs_main_command(request, *args, **kwargs):
     request: Request
         The Request object
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dictionary with request arguments.
         Request should contain the following:
@@ -1059,7 +1059,7 @@ def tcs_main_docstrings(request, *args, **kwargs):
     request: Request
         The Request object
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dictionary with request arguments. Currently unused
 
@@ -1471,7 +1471,7 @@ def ole_send_night_report(request, *args, **kwargs):
         The Request object
 
     args : `list`
-        List of addittional arguments. Currently unused.
+        List of additional arguments. Currently unused.
 
     kwargs : `dict`
         Dictionary with request arguments. Currently using the following keys:
@@ -1577,7 +1577,7 @@ def get_jira_tickets_report(request, *args, **kwargs):
         The Request object.
 
     args : `list`
-        List of addittional arguments. Currently unused.
+        List of additional arguments. Currently unused.
 
     kwargs : `dict`
         Dictionary with request arguments. Currently using the following keys:

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -857,6 +857,40 @@ def query_efd_timeseries(request, *args, **kwargs):
 
 @api_view(["POST"])
 @permission_classes((IsAuthenticated,))
+def query_efd_most_recent_timeseries(request, *args, **kwargs):
+    """Queries most recent data from an EFD timeseries
+    by redirecting the request to the Commander
+
+    Params
+    ------
+    request: Request
+        The Request object
+        Dictionary with request arguments.
+        Request should contain the following:
+            topic_name (required): String specifying the topic name.
+            fields (required): Array[String] specifying the topic fields.
+            num: Int specifying the number of most recent records to retrieve.
+            efd_instance (required): The specific EFD instance to query
+    args: list
+        List of addittional arguments. Currently unused
+    kwargs: dict
+        Dict of additional arguments. Currently unused
+
+    Returns
+    -------
+    Response
+        The response and status code of the request to the LOVE-Commander
+    """
+    url = (
+        f"http://{os.environ.get('COMMANDER_HOSTNAME')}"
+        f":{os.environ.get('COMMANDER_PORT')}/efd/top_timeseries"
+    )
+    response = requests.post(url, json=request.data)
+    return Response(response.json(), status=response.status_code)
+
+
+@api_view(["POST"])
+@permission_classes((IsAuthenticated,))
 def query_efd_logs(request, *args, **kwargs):
     """Queries data from an EFD timeseries by
     redirecting the request to the Commander

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -205,7 +205,7 @@ def upload_to_lfa(request, *args, **kwargs):
     request: Request
         The Request object
     args: list
-        List of addittional arguments. Currently unused
+        List of additional arguments. Currently unused
     kwargs: dict
         Dictionary with request arguments. Currently unused
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -705,6 +705,7 @@ def get_jira_obs_report(request_data):
                 ),
                 "reporter": issue["fields"]["creator"]["displayName"],
                 "created": issue["fields"]["created"].split(".")[0],
+                "systems": parse_obs_issue_systems(issue),
             }
             for issue in issues
         ]
@@ -1202,3 +1203,22 @@ def parse_obs_issues_array_to_plain_text(obs_issues):
         plain_text += f"Created by {issue.get('reporter')}\n"
 
     return plain_text
+
+
+def parse_obs_issue_systems(issue):
+    """Parse the OBS issue systems selection to a list of strings
+    containing the selected systems.
+
+    Parameters
+    ----------
+    issue : `dict`
+        The OBS issue got from the Jira API response.
+
+    Returns
+    -------
+    list
+        List of strings with the selected systems.
+    """
+    systemsPayload = issue["fields"][OBS_SYSTEMS_FIELD]["selection"][0]
+    systems = [system["name"] for system in systemsPayload]
+    return systems


### PR DESCRIPTION
This PR adds new api endpoints:

- `efd/top_timeseries`: to retrieve most recent timeseries (see https://github.com/lsst-ts/LOVE-commander/pull/79).
- `jira/report/<project>/`: to retrieve a list of Jira tickets for a specified day obs, currently only supporting OBS project queries.

It also updates respective code to the Nightreport API to support the new LOVE nightlog v2, see https://github.com/lsst-ts/LOVE-frontend/pull/718.