### PR TITLE
Remove ComCam and Star Tracker subsections from the Simonyi Survey Telescope group in the ASummary State View at summit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.4.1
 ------
 
+* Remove ComCam and Star Tracker subsections from the Simonyi Survey Telescope group in the ASummary State View at summit. `<https://github.com/lsst-ts/LOVE-manager/pull/326>`_
 * Bump urllib3 from 1.26.19 to 2.5.0 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/324>`_
 * Bump requests from 2.32.2 to 2.32.4 in /manager `<https://github.com/lsst-ts/LOVE-manager/pull/321>`_
 

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -989,20 +989,6 @@
                       "salindex": 1
                     }
                   ],
-                  "ComCam": [
-                    {
-                      "name": "CCCamera",
-                      "salindex": 0
-                    },
-                    {
-                      "name": "CCOODS",
-                      "salindex": 0
-                    },
-                    {
-                      "name": "CCHeaderService",
-                      "salindex": 0
-                    }
-                  ],
                   "LSSTCam": [
                     {
                       "name": "MTCamera",
@@ -1015,32 +1001,6 @@
                     {
                       "name": "MTHeaderService",
                       "salindex": 0
-                    }
-                  ],
-                  "Star Tracker": [
-                    {
-                      "name": "GenericCamera",
-                      "salindex": 101
-                    },
-                    {
-                      "name": "GCHeaderService",
-                      "salindex": 101
-                    },
-                    {
-                      "name": "GenericCamera",
-                      "salindex": 102
-                    },
-                    {
-                      "name": "GCHeaderService",
-                      "salindex": 102
-                    },
-                    {
-                      "name": "GenericCamera",
-                      "salindex": 103
-                    },
-                    {
-                      "name": "GCHeaderService",
-                      "salindex": 103
                     }
                   ],
                   "Calibration Systems": [


### PR DESCRIPTION
This PR removes the `ComCam`  and `Star Tracker` sections from the `Simonyi Survey Telescope` group in the ASummary State View from Summit `ui-framework` fixture.