### PR TITLE
Add HVAC to ui-framework fixtures on base and tucson.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.4.2
+------
+
+* Add HVAC to ui-framework fixtures on base and tucson. `<https://github.com/lsst-ts/LOVE-manager/pull/327>`_
+
 v7.4.1
 ------
 

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -498,6 +498,10 @@
                       "salindex": 0
                     },
                     {
+                      "name": "HVAC",
+                      "salindex": 0
+                    },
+                    {
                       "name": "DIMM",
                       "salindex": 1
                     },

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -498,6 +498,10 @@
                       "salindex": 0
                     },
                     {
+                      "name": "HVAC",
+                      "salindex": 0
+                    },
+                    {
                       "name": "DIMM",
                       "salindex": 1
                     },


### PR DESCRIPTION
This PR adds the HVAC CSCs to the BTS and TTS ui-framework fixtures: `Observatory / Environment / HVAC`.