### PR TITLE
Fix deprecated jql Jira interface.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v7.4.3
 ------
 
+* Fix deprecated jql Jira interface. `<https://github.com/lsst-ts/LOVE-manager/pull/329>`_
 * Fix the jira_comment function to avoid trying to update the time_lost field if the project doesn't support it. `<https://github.com/lsst-ts/LOVE-manager/pull/328>`_
 
 v7.4.2

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -37,6 +37,7 @@ from rest_framework.test import APIClient
 from manager.utils import (
     JIRA_PROJECTS_WITH_TIME_LOSS,
     OBS_SYSTEMS_FIELD,
+    OBS_TICKETS_FIELDS,
     OBS_TIME_LOST_FIELD,
     get_jira_obs_report,
     get_obsday_from_tai,
@@ -559,7 +560,8 @@ class JiraTestCase(TestCase):
         )
         url_call_2 = (
             f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
-            f"/rest/api/latest/search?jql={quote(jql_query)}"
+            f"/rest/api/latest/search/jql?jql={quote(jql_query)}"
+            f"&fields={OBS_TICKETS_FIELDS}"
         )
 
         response_2 = requests.Response()
@@ -710,7 +712,8 @@ class JiraAPITestCase(TestCase):
         )
         url_call_2 = (
             f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
-            f"/rest/api/latest/search?jql={quote(jql_query)}"
+            f"/rest/api/latest/search/jql?jql={quote(jql_query)}"
+            f"&fields={OBS_TICKETS_FIELDS}"
         )
         response_2 = requests.Response()
         response_2.status_code = 200
@@ -786,7 +789,8 @@ class JiraAPITestCase(TestCase):
         )
         url_call_2 = (
             f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
-            f"/rest/api/latest/search?jql={quote(jql_query)}"
+            f"/rest/api/latest/search/jql?jql={quote(jql_query)}"
+            f"&fields={OBS_TICKETS_FIELDS}"
         )
         response_2 = requests.Response()
         response_2.status_code = 200
@@ -846,7 +850,8 @@ class JiraAPITestCase(TestCase):
         )
         url_call_2 = (
             f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
-            f"/rest/api/latest/search?jql={quote(jql_query)}"
+            f"/rest/api/latest/search/jql?jql={quote(jql_query)}"
+            f"&fields={OBS_TICKETS_FIELDS}"
         )
 
         failed_response = requests.Response()

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -45,6 +45,9 @@ JSON_RESPONSE_ERROR_NOT_VALID_JSON = {"error": "Not a valid JSON response."}
 OBS_ISSUE_TYPE_ID = "10065"
 OBS_TIME_LOST_FIELD = "customfield_10106"
 OBS_SYSTEMS_FIELD = "customfield_10476"
+OBS_TICKETS_FIELDS = (
+    "summary,created,creator,system," f"{OBS_TIME_LOST_FIELD},{OBS_SYSTEMS_FIELD}"
+)
 
 DATETIME_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
@@ -696,7 +699,10 @@ def get_jira_obs_report(request_data):
         f"AND created <= '{final_day_obs_string} {end_date_user_time_string}'"
     )
 
-    url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/search?jql={quote(jql_query)}"
+    url = (
+        f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest"
+        f"/search/jql?jql={quote(jql_query)}&fields={OBS_TICKETS_FIELDS}"
+    )
     response = requests.get(url, headers=headers)
     if response.status_code == 200:
         issues = response.json()["issues"]


### PR DESCRIPTION
This PR fixes the Jira API interface used to retrieve OBS tickets. The old jql query method was [marked for deprecation the 31th of October of 2024](https://developer.atlassian.com/changelog/#CHANGE-2046), but got finally removed during these days (week of the 15th of September 2025). The fix was a slight adjustments to query the `jql` endpoint plus specifying the fields we want to  retrieve.