### PR TITLE
Fix time cut setting for EFD queries in the ole_send_night_report method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.5.14
+-------
+
+* Fix time cut setting for EFD queries in the ole_send_night_report method. `<https://github.com/lsst-ts/LOVE-manager/pull/366>`_
+
 v7.5.13
 -------
 

--- a/manager/api/tests/test_jira.py
+++ b/manager/api/tests/test_jira.py
@@ -39,7 +39,7 @@ from manager.utils import (
     OBS_TIME_LOST_FIELD,
     get_jira_obs_report,
     get_obsday_from_tai,
-    get_obsday_to_tai,
+    get_obsday_start_to_utc,
     handle_jira_payload,
     jira_comment,
     jira_ticket,
@@ -750,7 +750,7 @@ class JiraAPITestCase(TestCase):
         # Create a datetime object for the current date at 12:00 UTC
         current_tai_datetime = astropy.time.Time.now().tai.datetime
         current_day_obs = get_obsday_from_tai(current_tai_datetime)
-        twelve_utc = get_obsday_to_tai(current_day_obs)
+        twelve_utc = get_obsday_start_to_utc(current_day_obs)
         next_day = twelve_utc + timedelta(days=1)
         twelve_utc_day = twelve_utc.strftime("%Y-%m-%d")
         next_day_day = next_day.strftime("%Y-%m-%d")

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -17,16 +17,23 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-
+import datetime
 import json
 from unittest.mock import patch
 
+import astropy
 import requests
 import rest_framework.response
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from manager.utils import DATETIME_ISO_FORMAT, ERROR_OBS_TICKETS, get_tai_from_utc
+from manager.utils import (
+    DATETIME_ISO_FORMAT,
+    ERROR_OBS_TICKETS,
+    get_obsday_end_to_utc,
+    get_obsday_from_tai,
+    get_tai_from_utc,
+)
 from rest_framework.test import APIClient
 
 from api.models import Token
@@ -757,6 +764,38 @@ class NightReportTestCase(TestCase):
         url = reverse("OLE-nightreport-send-report", args=[self.response_report["id"]])
         response = self.client.post(url, data=self.send_report_payload, format="json")
         self.assertEqual(response.status_code, 200)
+
+        report_obsday_end_tai = get_tai_from_utc(get_obsday_end_to_utc(int(self.response_report["day_obs"])))
+
+        # Check the observatory status & CSCs status from EFD
+        # is called with the end of the report observing day
+        # in TAI scale as argument.
+        observatory_status_efd_time_cut_tai = (
+            mock_get_nightreport_observatory_status_from_efd_client.call_args[0][1]
+        )
+        cscs_status_efd_time_cut_tai = mock_get_nightreport_cscs_status_from_efd_client.call_args[0][1]
+        assert observatory_status_efd_time_cut_tai == report_obsday_end_tai
+        assert cscs_status_efd_time_cut_tai == report_obsday_end_tai
+
+        # Simulate night report being sent on the current obs day
+        # thus EFD status methods are called with the current time (TAI)
+        # instead of the report obs day end.
+        curr_tai = astropy.time.Time.now().tai.datetime
+        mock_get_last_valid_night_report_client.return_value = {
+            **self.response_report,
+            "day_obs": get_obsday_from_tai(curr_tai),
+        }
+        response = self.client.post(url, data=self.send_report_payload, format="json")
+        self.assertEqual(response.status_code, 200)
+
+        observatory_status_efd_time_cut_tai = (
+            mock_get_nightreport_observatory_status_from_efd_client.call_args[0][1]
+        )
+        cscs_status_efd_time_cut_tai = mock_get_nightreport_cscs_status_from_efd_client.call_args[0][1]
+        self.assertAlmostEqual(
+            observatory_status_efd_time_cut_tai, curr_tai, delta=datetime.timedelta(seconds=1)
+        )
+        self.assertAlmostEqual(cscs_status_efd_time_cut_tai, curr_tai, delta=datetime.timedelta(seconds=1))
 
         mock_requests_patch.stop()
         mock_get_jira_obs_report.stop()

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -48,6 +48,7 @@ from manager.utils import (
     get_last_valid_night_report,
     get_nightreport_cscs_status_from_efd,
     get_nightreport_observatory_status_from_efd,
+    get_obsday_end_to_utc,
     get_obsday_from_tai,
     get_obsday_iso,
     get_tai_from_utc,
@@ -1472,6 +1473,7 @@ def ole_send_night_report(request, *args, **kwargs):
 
     # Get current report
     last_valid_report = get_last_valid_night_report(int(json_data["day_obs"]))
+
     if last_valid_report is None or last_valid_report["id"] != pk:
         return Response(
             {"error": NIGHT_REPORT_CONFLICT_MESSAGE},
@@ -1480,11 +1482,19 @@ def ole_send_night_report(request, *args, **kwargs):
     if last_valid_report["date_sent"] is not None:
         return Response({"error": "Night report already sent"}, status=status.HTTP_400_BAD_REQUEST)
 
+    last_valid_report_obsday = int(last_valid_report["day_obs"])
+
+    # Set time cut (TAI) for EFD queries. If the report is for a past obs day,
+    # we set the cut to the end of that obs day.
+    report_obsday_end_tai = get_tai_from_utc(get_obsday_end_to_utc(last_valid_report_obsday))
+    curr_tai = astropy.time.Time.now().tai.datetime
+    efd_time_cut = min(curr_tai, report_obsday_end_tai)
+
     # Get observatory and CSCS status
     try:
         efd_instance = get_efd_instance_from_request(request)
-        observatory_status = get_nightreport_observatory_status_from_efd(efd_instance)
-        cscs_status = get_nightreport_cscs_status_from_efd(efd_instance)
+        observatory_status = get_nightreport_observatory_status_from_efd(efd_instance, efd_time_cut)
+        cscs_status = get_nightreport_cscs_status_from_efd(efd_instance, efd_time_cut)
         last_valid_report["observatory_status"] = observatory_status
         last_valid_report["cscs_status"] = cscs_status
     except Exception as e:
@@ -1495,7 +1505,7 @@ def ole_send_night_report(request, *args, **kwargs):
 
     # Get JIRA observation issues
     try:
-        last_valid_report["obs_issues"] = get_jira_obs_report({"day_obs": last_valid_report["day_obs"]})
+        last_valid_report["obs_issues"] = get_jira_obs_report({"day_obs": last_valid_report_obsday})
     except Exception as e:
         return Response(
             {"error": str(e)},
@@ -1513,7 +1523,7 @@ def ole_send_night_report(request, *args, **kwargs):
         )
 
     # Handle email sending
-    subject = f"Rubin Observatory Night Report {get_obsday_iso(json_data['day_obs'])}"
+    subject = f"Rubin Observatory Night Report {get_obsday_iso(last_valid_report_obsday)}"
     email_sent = send_smtp_email(
         os.environ.get("NIGHTREPORT_MAIL_ADDRESS", "rubin-night-log@lists.lsst.org"),
         subject,

--- a/manager/manager/tests/test_utils.py
+++ b/manager/manager/tests/test_utils.py
@@ -16,6 +16,7 @@ from manager.utils import (
     get_last_valid_night_report,
     get_nightreport_cscs_status_from_efd,
     get_nightreport_observatory_status_from_efd,
+    get_obsday_end_to_utc,
 )
 
 observatory_status_efd_response = {
@@ -360,3 +361,16 @@ class UtilsTestCase(TestCase):
             mock_request.get_host.return_value = host
             efd_instance = get_efd_instance_from_request(mock_request)
             assert efd_instance == expected_efd
+
+    def test_get_obsday_end_to_utc(self):
+        # Test with a known obsday end time
+        obsday = 20251001
+        obsday_end_utc = get_obsday_end_to_utc(obsday)
+        expected_obsday_end_utc = "2025-10-02T12:00:00"
+        assert obsday_end_utc.isoformat() == expected_obsday_end_utc
+
+        # Test with invalid obsday format
+        invalid_obsdays = [20250931, 202510, 202510001, None]
+        for obsday in invalid_obsdays:
+            with pytest.raises(ValueError):
+                get_obsday_end_to_utc(obsday)

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -689,8 +689,8 @@ def get_jira_obs_report(request_data):
         - reporter: The issue reporter
         - created: The issue creation date
     """
-    intitial_day_obs_tai = get_obsday_to_tai(request_data.get("day_obs"))
-    final_day_obs_tai = intitial_day_obs_tai + timedelta(days=1)
+    intitial_day_obs_utc = get_obsday_start_to_utc(request_data.get("day_obs"))
+    final_day_obs_utc = intitial_day_obs_utc + timedelta(days=1)
 
     headers = {
         "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",
@@ -705,8 +705,8 @@ def get_jira_obs_report(request_data):
     else:
         raise Exception(f"Error getting user timezone from {os.environ.get('JIRA_API_HOSTNAME')}")
 
-    start_date_user_datetime = intitial_day_obs_tai.replace(tzinfo=timezone("UTC")).astimezone(user_timezone)
-    end_date_user_datetime = final_day_obs_tai.replace(tzinfo=timezone("UTC")).astimezone(user_timezone)
+    start_date_user_datetime = intitial_day_obs_utc.replace(tzinfo=timezone("UTC")).astimezone(user_timezone)
+    end_date_user_datetime = final_day_obs_utc.replace(tzinfo=timezone("UTC")).astimezone(user_timezone)
 
     initial_day_obs_string = start_date_user_datetime.strftime("%Y-%m-%d")
     final_day_obs_string = end_date_user_datetime.strftime("%Y-%m-%d")
@@ -792,25 +792,6 @@ def get_obsday_from_tai(tai):
     return observing_day
 
 
-def get_obsday_to_tai(obsday):
-    """Return the TAI timestamp from an observing day.
-
-    The TAI timestamp is set to 12:00 UTC of the observing day.
-
-    Parameters
-    ----------
-    obsday : `int`
-        The observing day in the format "YYYYMMDD" as an integer
-
-    Returns
-    -------
-    `datetime.datetime`
-        The TAI timestamp
-    """
-    obsday_iso = get_obsday_iso(obsday)
-    return Time(f"{obsday_iso}T12:00:00", scale="tai").datetime
-
-
 def get_obsday_iso(obsday):
     """Return the observing day in ISO format.
 
@@ -825,6 +806,46 @@ def get_obsday_iso(obsday):
         The observing day in ISO format
     """
     return f"{str(obsday)[:4]}-{str(obsday)[4:6]}-{str(obsday)[6:8]}"
+
+
+def get_obsday_start_to_utc(obsday):
+    """Return the start of the observing day in UTC.
+
+    The start of the observing day is set to 12:00 UTC
+    of the current calendar day.
+
+    Parameters
+    ----------
+    obsday : `int`
+        The observing day in the format "YYYYMMDD" as an integer.
+
+    Returns
+    -------
+    `datetime.datetime`
+        The UTC timestamp of the start of the observing day.
+    """
+    obsday_iso = get_obsday_iso(obsday)
+    return Time(f"{obsday_iso}T12:00:00", scale="utc").datetime
+
+
+def get_obsday_end_to_utc(obsday):
+    """Return the end of the observing day in UTC.
+
+    The end of the observing day is set to 12:00 UTC
+    of the next calendar day.
+
+    Parameters
+    ----------
+    obsday : `int`
+        The observing day in the format "YYYYMMDD" as an integer.
+
+    Returns
+    -------
+    `datetime.datetime`
+        The UTC timestamp of the end of the observing day
+    """
+    obsday_iso = get_obsday_iso(obsday)
+    return Time(f"{obsday_iso}T12:00:00", scale="utc").datetime + timedelta(days=1)
 
 
 def get_tai_to_utc() -> float:
@@ -1303,12 +1324,20 @@ def parse_obs_issue_systems(issue):
     return systems
 
 
-def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd"):
+def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_cut=None):
     """Get the observatory status from the EFD.
 
     Connect to the EFD LOVE-commander interface by querying
     the top_timeseries endpoint to get the current
     observatory status.
+
+    Parameters
+    ----------
+    efd_instance : str
+        Name of the EFD instance to query (defaults to "summit_efd").
+    time_cut : None | datetime
+        Optional datetime to use for the EFD `time_cut`. If None, the current
+        time (TAI) is used.
 
     Returns
     -------
@@ -1393,11 +1422,13 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd"):
             state = 0
         return state_map.get(state, "UNKNOWN")
 
-    curr_tai = astropy.time.Time.now().tai.datetime
+    if time_cut is None:
+        time_cut = astropy.time.Time.now().tai.datetime
+
     payload = {
         "cscs": cscs,
         "num": 1,
-        "time_cut": curr_tai.isoformat(),
+        "time_cut": time_cut.isoformat(),
         "efd_instance": efd_instance,
     }
     response = requests.post(url, json=payload)
@@ -1496,12 +1527,20 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd"):
     raise Exception("Error getting observatory status from EFD.")
 
 
-def get_nightreport_cscs_status_from_efd(efd_instance="summit_efd"):
+def get_nightreport_cscs_status_from_efd(efd_instance="summit_efd", time_cut=None):
     """Get the CSCS status from the EFD.
 
     Connect to the EFD LOVE-commander interface by querying
     the top_timeseries endpoint to get the current
     CSCs status.
+
+    Parameters
+    ----------
+    efd_instance : str
+        Name of the EFD instance to query (defaults to "summit_efd").
+    time_cut : None | datetime
+        Optional datetime to use for the EFD `time_cut`. If None, the current
+        time (TAI) is used.
 
     Returns
     -------
@@ -1553,11 +1592,13 @@ def get_nightreport_cscs_status_from_efd(efd_instance="summit_efd"):
         except Exception:
             return 0
 
-    curr_tai = astropy.time.Time.now().tai.datetime
+    if time_cut is None:
+        time_cut = astropy.time.Time.now().tai.datetime
+
     payload = {
         "cscs": cscs,
         "num": 1,
-        "time_cut": curr_tai.isoformat(),
+        "time_cut": time_cut.isoformat(),
         "efd_instance": efd_instance,
     }
     response = requests.post(url, json=payload)


### PR DESCRIPTION
This PR extends the `ole_send_night_report` to properly account for EFD queries time cuts. When historic night reports are sent we need to define a time cut to query the respective topics in the EFD. As we don't have a timestamp because the reports are old and we don't know when the night finished we set the time cut to the end of the respective observing day (12:00 UTC of the next calendar day). In the case the night report is sent in the same respective observing day, then the current timestamp is used (as it indicates when the night finished).