### PR TITLE
Add new ESS CSCs 309, 310 and 311 to summary state views.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,12 @@
 Version History
 ===============
 
+v
+
 v7.5.14
 -------
 
+* Add new ESS CSCs 309, 310 and 311 to summary state views. `<https://github.com/lsst-ts/LOVE-manager/pull/368>`_
 * Fix time cut setting for EFD queries in the ole_send_night_report method. `<https://github.com/lsst-ts/LOVE-manager/pull/366>`_
 
 v7.5.13

--- a/manager/ui_framework/fixtures/initial_data_base.json
+++ b/manager/ui_framework/fixtures/initial_data_base.json
@@ -645,6 +645,18 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 309
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 310
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 311
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 404
                     },
                     {

--- a/manager/ui_framework/fixtures/initial_data_summit.json
+++ b/manager/ui_framework/fixtures/initial_data_summit.json
@@ -880,6 +880,18 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 309
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 310
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 311
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 404
                     },
                     {

--- a/manager/ui_framework/fixtures/initial_data_tucson.json
+++ b/manager/ui_framework/fixtures/initial_data_tucson.json
@@ -645,6 +645,18 @@
                     },
                     {
                       "name": "ESS",
+                      "salindex": 309
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 310
+                    },
+                    {
+                      "name": "ESS",
+                      "salindex": 311
+                    },
+                    {
+                      "name": "ESS",
                       "salindex": 404
                     },
                     {


### PR DESCRIPTION
This PR adds new ESS CSCs to the ui-framework fixtures for summit, base and tucson in the following groups:

- Observatory / Environment / ESS:309
- Observatory / Environment / ESS:310
- Observatory / Environment / ESS:311