### PR TITLE
Add M1M3 detailedState field to night report email.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,10 @@
 Version History
 ===============
 
-v
+v7.5.15
+-------
+
+* Add M1M3 detailedState field to night report email. `<https://github.com/lsst-ts/LOVE-manager/pull/370>`_
 
 v7.5.14
 -------

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -766,22 +766,25 @@ class NightReportTestCase(TestCase):
         response = self.client.post(url, data=self.send_report_payload, format="json")
         self.assertEqual(response.status_code, 200)
 
-        report_obsday_end_tai = get_tai_from_utc(get_obsday_end_to_utc(int(self.response_report["day_obs"])))
+        report_obsday_end_utc = get_obsday_end_to_utc(int(self.response_report["day_obs"]))
 
         # Check the observatory status & CSCs status from EFD
         # is called with the end of the report observing day
-        # in TAI scale as argument.
-        observatory_status_efd_time_cut_tai = (
+        # in UTC scale as argument.
+        observatory_status_efd_time_cut_utc = (
             mock_get_nightreport_observatory_status_from_efd_client.call_args[0][1]
         )
-        cscs_status_efd_time_cut_tai = mock_get_nightreport_cscs_status_from_efd_client.call_args[0][1]
-        assert observatory_status_efd_time_cut_tai == report_obsday_end_tai
-        assert cscs_status_efd_time_cut_tai == report_obsday_end_tai
+        cscs_status_efd_time_cut_utc = mock_get_nightreport_cscs_status_from_efd_client.call_args[0][1]
+        assert observatory_status_efd_time_cut_utc == report_obsday_end_utc
+        assert cscs_status_efd_time_cut_utc == report_obsday_end_utc
 
         # Simulate night report being sent on the current obs day
-        # thus EFD status methods are called with the current time (TAI)
+        # thus EFD status methods are called with the current time (UTC)
         # instead of the report obs day end.
-        curr_tai = astropy.time.Time.now().tai.datetime
+        curr_time = astropy.time.Time.now()
+        curr_utc = curr_time.utc.datetime
+        curr_tai = curr_time.tai.datetime
+
         mock_get_last_valid_night_report_client.return_value = {
             **self.response_report,
             "day_obs": get_obsday_from_tai(curr_tai),
@@ -789,14 +792,14 @@ class NightReportTestCase(TestCase):
         response = self.client.post(url, data=self.send_report_payload, format="json")
         self.assertEqual(response.status_code, 200)
 
-        observatory_status_efd_time_cut_tai = (
+        observatory_status_efd_time_cut_utc = (
             mock_get_nightreport_observatory_status_from_efd_client.call_args[0][1]
         )
-        cscs_status_efd_time_cut_tai = mock_get_nightreport_cscs_status_from_efd_client.call_args[0][1]
+        cscs_status_efd_time_cut_utc = mock_get_nightreport_cscs_status_from_efd_client.call_args[0][1]
         self.assertAlmostEqual(
-            observatory_status_efd_time_cut_tai, curr_tai, delta=datetime.timedelta(seconds=1)
+            observatory_status_efd_time_cut_utc, curr_utc, delta=datetime.timedelta(seconds=1)
         )
-        self.assertAlmostEqual(cscs_status_efd_time_cut_tai, curr_tai, delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEqual(cscs_status_efd_time_cut_utc, curr_utc, delta=datetime.timedelta(seconds=1))
 
         mock_requests_patch.stop()
         mock_get_jira_obs_report.stop()

--- a/manager/api/tests/test_ole.py
+++ b/manager/api/tests/test_ole.py
@@ -562,6 +562,7 @@ class NightReportTestCase(TestCase):
             "simonyiOilSupplySystemState": "UNKNOWN",
             "simonyiPowerSupplySystemState": "UNKNOWN",
             "simonyiLockingPinsSystemState": "UNKNOWN",
+            "simonyiM1M3DetailedState": "UNKNOWN",
             "auxtelAzimuth": 200,
             "auxtelElevation": 60,
             "auxtelDomeAzimuth": 250,

--- a/manager/api/views.py
+++ b/manager/api/views.py
@@ -1486,9 +1486,9 @@ def ole_send_night_report(request, *args, **kwargs):
 
     # Set time cut (TAI) for EFD queries. If the report is for a past obs day,
     # we set the cut to the end of that obs day.
-    report_obsday_end_tai = get_tai_from_utc(get_obsday_end_to_utc(last_valid_report_obsday))
-    curr_tai = astropy.time.Time.now().tai.datetime
-    efd_time_cut = min(curr_tai, report_obsday_end_tai)
+    report_obsday_end_utc = get_obsday_end_to_utc(last_valid_report_obsday)
+    curr_utc = astropy.time.Time.now().datetime
+    efd_time_cut = min(curr_utc, report_obsday_end_utc)
 
     # Get observatory and CSCS status
     try:

--- a/manager/manager/tests/test_utils.py
+++ b/manager/manager/tests/test_utils.py
@@ -9,7 +9,7 @@ from manager.utils import (
     ATPNEUMATICS_MIRROR_COVER_STATE_MAP,
     EFD_INSTACES,
     MTMOUNT_DEPLOYABLE_MOTION_STATE_MAP,
-    MTMOUNT_MT_MOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
+    MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
     MTMOUNT_POWER_STATE_MAP,
     arrange_nightlydigest_urls_for_obsday,
     get_efd_instance_from_request,
@@ -262,7 +262,7 @@ class UtilsTestCase(TestCase):
             (
                 "MTMount-0-logevent_elevationLockingPinMotionState",
                 "simonyiLockingPinsSystemState",
-                MTMOUNT_MT_MOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
+                MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
             ),
             (
                 "ATPneumatics-0-logevent_m1CoverState",

--- a/manager/manager/tests/test_utils.py
+++ b/manager/manager/tests/test_utils.py
@@ -8,6 +8,7 @@ from django.test.utils import override_settings
 from manager.utils import (
     ATPNEUMATICS_MIRROR_COVER_STATE_MAP,
     EFD_INSTACES,
+    MTM1M3_DETAILED_STATE_MAP,
     MTMOUNT_DEPLOYABLE_MOTION_STATE_MAP,
     MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
     MTMOUNT_POWER_STATE_MAP,
@@ -43,6 +44,9 @@ observatory_status_efd_response = {
     },
     "MTRotator-0-rotation": {
         "actualPosition": [{"ts": "2025-10-24 19:22:13.100240+00:00", "value": -0.0016296546160410818}]
+    },
+    "MTM1M3-0-logevent_detailedState": {
+        "detailedState": [{"ts": "2025-10-24 19:22:13.100240+00:00", "value": 5}]
     },
     "ATMCS-0-mount_AzEl_Encoders": {
         "azimuthCalculatedAngle0": [{"ts": "2025-10-24 19:22:03.259886+00:00", "value": 15.1014567}],
@@ -209,6 +213,7 @@ class UtilsTestCase(TestCase):
             "simonyiOilSupplySystemState",
             "simonyiPowerSupplySystemState",
             "simonyiLockingPinsSystemState",
+            "simonyiM1M3DetailedState",
             "auxtelAzimuth",
             "auxtelElevation",
             "auxtelDomeAzimuth",
@@ -225,6 +230,7 @@ class UtilsTestCase(TestCase):
         assert observatory_status["simonyiOilSupplySystemState"] == "ON"
         assert observatory_status["simonyiPowerSupplySystemState"] == "ON"
         assert observatory_status["simonyiLockingPinsSystemState"] == "UNLOCKED"
+        assert observatory_status["simonyiM1M3DetailedState"] == "PARKED"
         assert observatory_status["auxtelAzimuth"] == "15.10°"
         assert observatory_status["auxtelElevation"] == "70.00°"
         assert observatory_status["auxtelDomeAzimuth"] == "104.66°"
@@ -268,6 +274,11 @@ class UtilsTestCase(TestCase):
                 "ATPneumatics-0-logevent_m1CoverState",
                 "auxtelMirrorCoversState",
                 ATPNEUMATICS_MIRROR_COVER_STATE_MAP,
+            ),
+            (
+                "MTM1M3-0-logevent_detailedState",
+                "simonyiM1M3DetailedState",
+                MTM1M3_DETAILED_STATE_MAP,
             ),
         ]
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -80,7 +80,7 @@ MTMOUNT_POWER_STATE_MAP = {
     15: "UNKNOWN",
 }
 
-MTMOUNT_MT_MOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP = {
+MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP = {
     0: "LOCKED",
     1: "TEST",
     2: "UNLOCKED",
@@ -1490,7 +1490,7 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_
                 data,
                 "MTMount-0-logevent_elevationLockingPinMotionState",
                 "state",
-                MTMOUNT_MT_MOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
+                MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
             ),
             "auxtelAzimuth": parse_measurement(
                 get_efd_data_measurement(

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -1359,7 +1359,7 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_
         Name of the EFD instance to query (defaults to "summit_efd").
     time_cut : None | datetime
         Optional datetime to use for the EFD `time_cut`. If None, the current
-        time (TAI) is used.
+        datetime is used.
 
     Returns
     -------
@@ -1451,7 +1451,7 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_
         return state_map.get(state, "UNKNOWN")
 
     if time_cut is None:
-        time_cut = astropy.time.Time.now().tai.datetime
+        time_cut = astropy.time.Time.now().datetime
 
     payload = {
         "cscs": cscs,
@@ -1574,7 +1574,7 @@ def get_nightreport_cscs_status_from_efd(efd_instance="summit_efd", time_cut=Non
         Name of the EFD instance to query (defaults to "summit_efd").
     time_cut : None | datetime
         Optional datetime to use for the EFD `time_cut`. If None, the current
-        time (TAI) is used.
+        datetime is used.
 
     Returns
     -------
@@ -1627,7 +1627,7 @@ def get_nightreport_cscs_status_from_efd(efd_instance="summit_efd", time_cut=Non
             return 0
 
     if time_cut is None:
-        time_cut = astropy.time.Time.now().tai.datetime
+        time_cut = astropy.time.Time.now().datetime
 
     payload = {
         "cscs": cscs,

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -1720,37 +1720,21 @@ def parse_observatory_status_to_plain_text(observatory_status):
     str
         The observatory status in plain text format
     """
-    maintel_params_units = {
-        "simonyiAzimuth": "°",
-        "simonyiElevation": "°",
-        "simonyiDomeAzimuth": "°",
-        "simonyiRotator": "°",
-    }
-    auxtel_params_units = {
-        "auxtelAzimuth": "°",
-        "auxtelElevation": "°",
-        "auxtelDomeAzimuth": "°",
-    }
-
     plain_text = ""
     plain_text += "Simonyi Telescope: "
-    plain_text += f"el = {observatory_status['simonyiElevation']}{maintel_params_units['simonyiElevation']}, "
-    plain_text += f"az = {observatory_status['simonyiAzimuth']}{maintel_params_units['simonyiAzimuth']}, "
-    plain_text += (
-        f"dome az = {observatory_status['simonyiDomeAzimuth']}{maintel_params_units['simonyiDomeAzimuth']}, "
-    )
-    plain_text += f"rotator = {observatory_status['simonyiRotator']}{maintel_params_units['simonyiRotator']}."
+    plain_text += f"el = {observatory_status['simonyiElevation']}, "
+    plain_text += f"az = {observatory_status['simonyiAzimuth']}, "
+    plain_text += f"dome az = {observatory_status['simonyiDomeAzimuth']}, "
+    plain_text += f"rotator = {observatory_status['simonyiRotator']}."
     plain_text += "\n"
     plain_text += f"Mirror covers: {observatory_status['simonyiMirrorCoversState']}, "
     plain_text += f"Oil supply system: {observatory_status['simonyiOilSupplySystemState']}, "
     plain_text += f"Power supply system: {observatory_status['simonyiPowerSupplySystemState']}, "
     plain_text += f"Locking pins system: {observatory_status['simonyiLockingPinsSystemState']}.\n"
     plain_text += "AuxTel Telescope: "
-    plain_text += f"el = {observatory_status['auxtelElevation']}{auxtel_params_units['auxtelElevation']}, "
-    plain_text += f"az = {observatory_status['auxtelAzimuth']}{auxtel_params_units['auxtelAzimuth']}, "
-    plain_text += (
-        f"dome az = {observatory_status['auxtelDomeAzimuth']}{auxtel_params_units['auxtelDomeAzimuth']}."
-    )
+    plain_text += f"el = {observatory_status['auxtelElevation']}, "
+    plain_text += f"az = {observatory_status['auxtelAzimuth']}, "
+    plain_text += f"dome az = {observatory_status['auxtelDomeAzimuth']}."
     plain_text += "\n"
     plain_text += f"Mirror covers: {observatory_status['auxtelMirrorCoversState']}.\n"
 

--- a/manager/manager/utils.py
+++ b/manager/manager/utils.py
@@ -88,6 +88,28 @@ MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP = {
     4: "MISMATCH",
 }
 
+MTM1M3_DETAILED_STATE_MAP = {
+    0: "UNKNOWN",
+    1: "DISABLED",
+    2: "FAULT",
+    3: "OFFLINE",
+    4: "STANDBY",
+    5: "PARKED",
+    6: "RAISING",
+    7: "ACTIVE",
+    8: "LOWERING",
+    9: "PARKEDENGINEERING",
+    10: "RAISINGENGINEERING",
+    11: "ACTIVEENGINEERING",
+    12: "LOWERINGENGINEERING",
+    13: "LOWERINGFAULT",
+    14: "PROFILEHARDPOINTCORRECTIONS",
+    15: "PAUSEDRAISING",
+    16: "PAUSEDRAISINGENGINEERING",
+    17: "PAUSEDLOWERING",
+    18: "PAUSEDLOWERINGENGINEERING",
+}
+
 ATPNEUMATICS_MIRROR_COVER_STATE_MAP = {
     1: "DISABLED",
     2: "ENABLED",
@@ -1352,6 +1374,7 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_
         - simonyiOilSupplySystemState
         - simonyiPowerSupplySystemState
         - simonyiLockingPinsSystemState
+        - simonyiM1M3DetailedState
         - auxtelAzimuth
         - auxtelElevation
         - auxtelDomeAzimuth
@@ -1381,6 +1404,11 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_
         "MTRotator": {
             0: {
                 "rotation": ["actualPosition"],
+            },
+        },
+        "MTM1M3": {
+            0: {
+                "logevent_detailedState": ["detailedState"],
             },
         },
         "ATMCS": {
@@ -1491,6 +1519,12 @@ def get_nightreport_observatory_status_from_efd(efd_instance="summit_efd", time_
                 "MTMount-0-logevent_elevationLockingPinMotionState",
                 "state",
                 MTMOUNT_ELEVATION_LOCKING_PIN_MOTION_STATE_MAP,
+            ),
+            "simonyiM1M3DetailedState": get_efd_data_state(
+                data,
+                "MTM1M3-0-logevent_detailedState",
+                "detailedState",
+                MTM1M3_DETAILED_STATE_MAP,
             ),
             "auxtelAzimuth": parse_measurement(
                 get_efd_data_measurement(
@@ -1628,6 +1662,7 @@ def parse_observatory_status_to_html_table(observatory_status):
         - simonyiOilSupplySystemState
         - simonyiPowerSupplySystemState
         - simonyiLockingPinsSystemState
+        - simonyiM1M3DetailedState
         - auxtelAzimuth
         - auxtelElevation
         - auxtelDomeAzimuth
@@ -1671,21 +1706,26 @@ def parse_observatory_status_to_html_table(observatory_status):
             <td>N/A</td>
         </tr>
         <tr style="background-color:#ffffff;">
+            <td style="white-space:nowrap;font-weight: bold;">M1M3 Detailed State</td>
+            <td>{observatory_status["simonyiM1M3DetailedState"]}</td>
+            <td>N/A</td>
+        </tr>
+        <tr style="background-color:#fafafa;">
             <td style="white-space:nowrap;font-weight: bold;">Mirror Covers State</td>
             <td>{observatory_status["simonyiMirrorCoversState"]}</td>
             <td>{observatory_status["auxtelMirrorCoversState"]}</td>
         </tr>
-        <tr style="background-color:#fafafa;">
+        <tr style="background-color:#ffffff;">
             <td style="white-space:nowrap;font-weight: bold;">Oil Supply System State</td>
             <td>{observatory_status["simonyiOilSupplySystemState"]}</td>
             <td>N/A</td>
         </tr>
-        <tr style="background-color:#ffffff;">
+        <tr style="background-color:#fafafa;">
             <td style="white-space:nowrap;font-weight: bold;">Power Supply System State</td>
             <td>{observatory_status["simonyiPowerSupplySystemState"]}</td>
             <td>N/A</td>
         </tr>
-        <tr style="background-color:#fafafa;">
+        <tr style="background-color:#ffffff;">
             <td style="white-space:nowrap;font-weight: bold;">Locking Pins System State</td>
             <td>{observatory_status["simonyiLockingPinsSystemState"]}</td>
             <td>N/A</td>
@@ -1710,6 +1750,7 @@ def parse_observatory_status_to_plain_text(observatory_status):
         - simonyiOilSupplySystemState
         - simonyiPowerSupplySystemState
         - simonyiLockingPinsSystemState
+        - simonyiM1M3DetailedState
         - auxtelAzimuth
         - auxtelElevation
         - auxtelDomeAzimuth
@@ -1727,6 +1768,7 @@ def parse_observatory_status_to_plain_text(observatory_status):
     plain_text += f"dome az = {observatory_status['simonyiDomeAzimuth']}, "
     plain_text += f"rotator = {observatory_status['simonyiRotator']}."
     plain_text += "\n"
+    plain_text += f"M1M3 Detailed State: {observatory_status['simonyiM1M3DetailedState']}, "
     plain_text += f"Mirror covers: {observatory_status['simonyiMirrorCoversState']}, "
     plain_text += f"Oil supply system: {observatory_status['simonyiOilSupplySystemState']}, "
     plain_text += f"Power supply system: {observatory_status['simonyiPowerSupplySystemState']}, "

--- a/manager/subscription/tests/test_subscriptions.py
+++ b/manager/subscription/tests/test_subscriptions.py
@@ -412,7 +412,7 @@ class TestSubscriptionCombinations:
         await producer_communicator.connect()
 
         # initial state is only useful for events
-        combinations = filter(lambda item: (item["category"] == "event"), self.combinations)
+        combinations = filter(lambda item: item["category"] == "event", self.combinations)
 
         for combination in combinations:
             # Act 1 (Subscribe producer)


### PR DESCRIPTION
This PR adds the M1M3 detailedState field to the night report email. Additionally a couple fixes to the current mail arrangement were done.