### PR TITLE
Pin redis to versions <8.0.0,>=7.4.0.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.5.16
+-------
+
+Pin redis to versions <8.0.0,>=7.4.0. `<https://github.com/lsst-ts/LOVE-manager/pull/371>`_
+
 v7.5.15
 -------
 

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -66,6 +66,7 @@ python-dateutil==2.9.0.post0
 python-ldap==3.4.5
 pytz==2024.1
 PyYAML==6.0.1
+redis<8.0.0,>=7.4.0 # versions >8.0.0 have issues with channel_redis configurations leading to connection timeout problems. See OSW-2464.
 requests==2.32.4
 ruamel.yaml==0.18.15
 ruamel.yaml.clib==0.2.14


### PR DESCRIPTION
This PR adds a explicit pin to redis for versions <8.0.0,>=7.4.0, in order to provide a quick workaround for an [issue in the channels_redis package](https://github.com/django/channels_redis/issues/422) with redis timeouts. The recent redis release (v8.0.0) changed default configurations for socket_timeout making channels_redis to require explicit configurations.